### PR TITLE
Add bamshift flag

### DIFF
--- a/gtars/src/uniwig/cli.rs
+++ b/gtars/src/uniwig/cli.rs
@@ -86,6 +86,13 @@ pub fn create_uniwig_cli() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("bamshift")
+                .long("bamshift")
+                .short('a')
+                .help("Set bam shift to False, i.e. uniwig will count raw reads without considering read direction.")
+                .action(ArgAction::SetFalse),
+        )
+        .arg(
             Arg::new("zoom")
                 .long("zoom")
                 .short('z')

--- a/gtars/src/uniwig/counting.rs
+++ b/gtars/src/uniwig/counting.rs
@@ -1316,7 +1316,7 @@ pub fn variable_shifted_bam_to_bw( records: &mut Box<Query<noodles::bgzf::reader
 
         let shifted_pos = get_shifted_pos(flags, start_site, end_site);
 
-        let mut adjusted_start_site = shifted_pos - smoothsize;
+        adjusted_start_site = shifted_pos - smoothsize;
 
 
         count += 1;

--- a/gtars/src/uniwig/mod.rs
+++ b/gtars/src/uniwig/mod.rs
@@ -147,6 +147,7 @@ pub fn run_uniwig(matches: &ArgMatches) {
         .expect("requires integer value");
 
     let score = matches.get_one::<bool>("score").unwrap_or_else(|| &false);
+    let bam_shift = matches.get_one::<bool>("bamshift").unwrap_or_else(|| &true);
 
     let debug = matches.get_one::<bool>("debug").unwrap_or_else(|| &false);
 
@@ -171,6 +172,7 @@ pub fn run_uniwig(matches: &ArgMatches) {
         *stepsize,
         *zoom,
         *debug,
+        *bam_shift,
     )
     .expect("Uniwig failed.");
 }
@@ -194,6 +196,7 @@ pub fn uniwig_main(
     stepsize: i32,
     zoom: i32,
     debug: bool,
+    bam_shift: bool,
 ) -> Result<(), Box<dyn Error>> {
     // Must create a Rayon thread pool in which to run our iterators
     let pool = rayon::ThreadPoolBuilder::new()
@@ -622,6 +625,7 @@ pub fn uniwig_main(
                 stepsize,
                 output_type,
                 debug,
+                bam_shift,
             );
         }
 
@@ -651,6 +655,7 @@ fn process_bam(
     stepsize: i32,
     output_type: &str,
     debug: bool,
+    bam_shift: bool,
 ) -> Result<(), Box<dyn Error>> {
     println!("Begin bam processing workflow...");
     let fp_string = filepath.to_string();
@@ -726,6 +731,7 @@ fn process_bam(
                                         &fp_string,
                                         &chrom_sizes_ref_path_string,
                                         "start",
+                                        bam_shift,
                                     );
                                 }
                                 &"end" => {
@@ -740,6 +746,7 @@ fn process_bam(
                                         &fp_string,
                                         &chrom_sizes_ref_path_string,
                                         "end",
+                                        bam_shift,
                                     );
                                 }
                                 &"core" => {
@@ -754,6 +761,7 @@ fn process_bam(
                                         &fp_string,
                                         &chrom_sizes_ref_path_string,
                                         "core",
+                                        bam_shift
                                     );
                                 }
                                 _ => {
@@ -1048,6 +1056,7 @@ fn process_bw_in_threads(
     fp_string: &String,
     chrom_sizes_ref_path_string: &String,
     sel: &str,
+    bam_shift:bool,
 ) {
     let (reader, writer) = os_pipe::pipe().unwrap();
     let write_fd = Arc::new(Mutex::new(writer));
@@ -1083,6 +1092,7 @@ fn process_bw_in_threads(
             &chromosome_string_cloned,
             sel_clone.as_str(),
             write_fd,
+            bam_shift,
         ) {
             Ok(_) => {
                 //eprintln!("Processing successful for {}", chromosome_string_cloned);
@@ -1146,9 +1156,10 @@ fn determine_counting_func(
     chromosome_string_cloned: &String,
     sel_clone: &str,
     write_fd: Arc<Mutex<PipeWriter>>,
+    bam_shift: bool,
 ) -> Result<(), BAMRecordError> {
 
-    let bam_shift: bool = true; // This is to ensure a shifted position workflow is used when doing bams
+    //let bam_shift: bool = true; // This is to ensure a shifted position workflow is used when doing bams
 
     let count_result: Result<(), BAMRecordError> =
 

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -394,6 +394,7 @@ mod tests {
             stepsize,
             zoom,
             false,
+            true,
         )
         .expect("Uniwig main failed!");
 
@@ -438,6 +439,7 @@ mod tests {
             stepsize,
             zoom,
             false,
+            true,
         )
         .expect("Uniwig main failed!");
 
@@ -483,6 +485,7 @@ mod tests {
             stepsize,
             zoom,
             false,
+            true,
         )
         .expect("Uniwig main failed!");
 
@@ -528,6 +531,7 @@ mod tests {
             stepsize,
             zoom,
             false,
+            true,
         )
         .expect("Uniwig main failed!");
         Ok(())
@@ -592,6 +596,7 @@ mod tests {
             stepsize,
             zoom,
             false,
+            true,
         );
 
         assert!(result.is_ok());
@@ -658,6 +663,7 @@ mod tests {
             stepsize,
             zoom,
             false,
+            true,
         );
 
         assert!(result.is_ok());
@@ -770,6 +776,7 @@ mod tests {
             stepsize,
             zoom,
             false,
+            true,
         );
 
         assert!(result.is_ok());
@@ -877,6 +884,7 @@ mod tests {
             stepsize,
             zoom,
             false,
+            true,
         )
         .expect("Uniwig main failed!");
 


### PR DESCRIPTION
I realized that position shifting is necessary for all bam workflows not just bam ->bed. Therefore, this PR adds a flag that can switch to and from using a position shifting function for the bam workflow. Instead of creating start,end, and core files, it will create a singular shift file. 