### PR TITLE
Fixes for #64 and #65

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,7 +19,7 @@ jobs:
           #  - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           - {os: ubuntu-latest,  r: 'release', rust-version: 'stable'}
-          - {os: ubuntu-latest,  r: 'devel',   rust-version: 'stable'}
+          #- {os: ubuntu-latest,  r: 'devel',   rust-version: 'stable'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
     steps:

--- a/gtars/Cargo.toml
+++ b/gtars/Cargo.toml
@@ -32,6 +32,7 @@ base64-url = "2.0.0"
 sha2 = "0.10.7"
 md-5 = "0.10.5"
 seq_io = "0.3.2"
+serde_json = "1.0.135"
 
 
 [dev-dependencies]

--- a/gtars/Cargo.toml
+++ b/gtars/Cargo.toml
@@ -32,7 +32,6 @@ base64-url = "2.0.0"
 sha2 = "0.10.7"
 md-5 = "0.10.5"
 seq_io = "0.3.2"
-serde_json = "1.0.135"
 
 
 [dev-dependencies]

--- a/gtars/src/common/utils.rs
+++ b/gtars/src/common/utils.rs
@@ -39,8 +39,8 @@ pub fn get_dynamic_reader(path: &Path) -> Result<BufReader<Box<dyn Read>>> {
 ///
 /// - file_path: path to the file to read, or '-' for stdin
 ///
-/// # Returns 
-/// 
+/// # Returns
+///
 /// A `BufReader` object for a given file path or stdin.
 pub fn get_dynamic_reader_w_stdin(file_path_str: &str) -> Result<BufReader<Box<dyn Read>>> {
     if file_path_str == "-" {
@@ -50,7 +50,6 @@ pub fn get_dynamic_reader_w_stdin(file_path_str: &str) -> Result<BufReader<Box<d
         return get_dynamic_reader(&file_path);
     }
 }
-
 
 ///
 /// Create a region-to-id hash-map from a list of regions

--- a/gtars/src/digests/mod.rs
+++ b/gtars/src/digests/mod.rs
@@ -13,21 +13,21 @@
 //! # Usage
 //!
 //! The `sha512t24u` function can be used to compute the GA4GH sha512t24 checksum of a string.
-//! 
+//!
 //! ```rust
 //! use gtars::digests::sha512t24u;
 //!
 //! let digest = sha512t24u("hello world");
 //! ```
-use std::io::prelude::{Read, Write};
-use std::io;
 use std::fs::File;
+use std::io;
+use std::io::prelude::{Read, Write};
 use std::path::Path;
 
 use anyhow::Result;
 use md5::Md5;
+use seq_io::fasta::{Reader, Record, RefRecord};
 use sha2::{Digest, Sha512};
-use seq_io::fasta::{Reader, RefRecord, Record};
 
 use crate::common::utils::get_dynamic_reader;
 
@@ -75,7 +75,6 @@ pub fn md5(string: &str) -> String {
     format!("{:x}", result)
 }
 
-
 /// Processes a FASTA file to compute the digests of each sequence in the file.
 ///
 /// This function reads a FASTA file, computes the SHA-512 and MD5 digests for each sequence,
@@ -103,7 +102,8 @@ pub fn digest_fasta(file_path: &str) -> Result<Vec<DigestResult>> {
     let file_reader = get_dynamic_reader(&path)?;
     let mut fasta_reader = Reader::new(file_reader);
     let mut results = Vec::new();
-    while let Some(record) = fasta_reader.next() {  // returns a RefRecord object
+    while let Some(record) = fasta_reader.next() {
+        // returns a RefRecord object
         let record = record.expect("Error found when retrieving next record.");
         let id = record.id().expect("No ID found for the FASTA record");
         let mut sha512_hasher = Sha512::new();
@@ -123,7 +123,7 @@ pub fn digest_fasta(file_path: &str) -> Result<Vec<DigestResult>> {
             id: id.to_string(),
             length: length,
             sha512t24u: sha512,
-            md5: md5
+            md5: md5,
         });
     }
     Ok(results)
@@ -169,7 +169,7 @@ mod tests {
         assert_eq!(results[0].sha512t24u, "iYtREV555dUFKg2_agSJW6suquUyPpMw");
         assert_eq!(results[0].md5, "5f63cfaa3ef61f88c9635fb9d18ec945");
     }
-    
+
     #[test]
     fn bogus_fasta_file() {
         let result = digest_fasta("tests/data/bogus.fa");

--- a/gtars/src/uniwig/counting.rs
+++ b/gtars/src/uniwig/counting.rs
@@ -34,9 +34,7 @@ pub fn start_end_counts(
     chrom_size: i32,
     smoothsize: i32,
     stepsize: i32,
-    shift: i32,
 ) -> (Vec<u32>, Vec<i32>) {
-    //let vin_iter = starts_vector.iter();
 
     let mut v_coordinate_positions: Vec<i32> = Vec::new(); // these are the final coordinates after any adjustments
     let mut v_coord_counts: Vec<u32> = Vec::new(); // u8 stores 0:255 This may be insufficient. u16 max is 65535
@@ -55,7 +53,7 @@ pub fn start_end_counts(
 
     adjusted_start_site = starts_vector[0]; // get first coordinate position
 
-    adjusted_start_site.0 = adjusted_start_site.0 - smoothsize + shift;
+    adjusted_start_site.0 = adjusted_start_site.0 - smoothsize;
 
     current_end_site = adjusted_start_site;
     current_end_site.0 = adjusted_start_site.0 + 1 + smoothsize * 2;
@@ -74,7 +72,7 @@ pub fn start_end_counts(
         coordinate_value = *coord;
 
         adjusted_start_site = coordinate_value;
-        adjusted_start_site.0 = coordinate_value.0 - smoothsize + shift;
+        adjusted_start_site.0 = coordinate_value.0 - smoothsize;
 
         let current_score = adjusted_start_site.1;
 
@@ -164,7 +162,6 @@ pub fn core_counts(
     ends_vector: &[(i32, i32)],
     chrom_size: i32,
     stepsize: i32,
-    shift: i32,
 ) -> (Vec<u32>, Vec<i32>) {
     let mut v_coordinate_positions: Vec<i32> = Vec::new(); // these are the final coordinates after any adjustments
     let mut v_coord_counts: Vec<u32> = Vec::new(); // u8 stores 0:255 This may be insufficient. u16 max is 65535
@@ -184,7 +181,7 @@ pub fn core_counts(
     current_start_site = starts_vector[0]; // get first coordinate position
     current_end_site = ends_vector[0];
 
-    current_start_site.0 = current_start_site.0 + shift;
+    current_start_site.0 = current_start_site.0;
 
     if current_start_site.0 < 1 {
         current_start_site.0 = 1;
@@ -201,7 +198,7 @@ pub fn core_counts(
 
         current_start_site = coordinate_value;
 
-        current_start_site.0 = current_start_site.0 + shift;
+        current_start_site.0 = current_start_site.0;
 
         let current_score = current_start_site.1;
         count += current_score;

--- a/gtars/src/uniwig/counting.rs
+++ b/gtars/src/uniwig/counting.rs
@@ -35,7 +35,6 @@ pub fn start_end_counts(
     smoothsize: i32,
     stepsize: i32,
 ) -> (Vec<u32>, Vec<i32>) {
-
     let mut v_coordinate_positions: Vec<i32> = Vec::new(); // these are the final coordinates after any adjustments
     let mut v_coord_counts: Vec<u32> = Vec::new(); // u8 stores 0:255 This may be insufficient. u16 max is 65535
 

--- a/gtars/src/uniwig/mod.rs
+++ b/gtars/src/uniwig/mod.rs
@@ -5,7 +5,7 @@ use indicatif::ProgressBar;
 
 use rayon::prelude::*;
 use std::error::Error;
-use std::fs::File;
+use std::fs::{remove_file, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 
 use crate::uniwig::counting::{
@@ -237,6 +237,8 @@ pub fn uniwig_main(
     meta_data_file_names[1] = format!("{}{}.{}", bwfileheader, "end", "meta");
     meta_data_file_names[2] = format!("{}{}.{}", bwfileheader, "core", "meta");
 
+    let mut npy_meta_data_map: HashMap<String, HashMap<String, i32>> = HashMap::new();
+
     let chrom_sizes = match read_chromosome_sizes(chromsizerefpath) {
         // original program gets chromosome size from a .sizes file, e.g. chr1 248956422
         // the original program simply pushes 0's until the end of the chromosome length and writes these to file.
@@ -251,16 +253,16 @@ pub fn uniwig_main(
     match input_filetype {
         //BED AND NARROWPEAK WORKFLOW
         Ok(FileType::BED) | Ok(FileType::NARROWPEAK) => {
+            // Pare down chromosomes if necessary
+            let mut final_chromosomes =
+                get_final_chromosomes(&input_filetype, filepath, &chrom_sizes, score);
+
             // Some housekeeping depending on output type
             let og_output_type = output_type; // need this later for conversion
             let mut output_type = output_type;
             if output_type == "bedgraph" || output_type == "bw" || output_type == "bigwig" {
                 output_type = "bedGraph" // we must create bedgraphs first before creating bigwig files
             }
-
-            // Pare down chromosomes if necessary
-            let mut final_chromosomes =
-                get_final_chromosomes(&input_filetype, filepath, &chrom_sizes, score);
 
             let bar = ProgressBar::new(final_chromosomes.len() as u64);
 
@@ -586,6 +588,59 @@ pub fn uniwig_main(
                             &final_chromosomes,
                         );
                     }
+                }
+                "npy" =>{
+                    // populate hashmap for the npy meta data
+                    for chromosome in final_chromosomes.iter(){
+                        let chr_name = chromosome.chrom.clone();
+                        let current_chrom_size =
+                            *chrom_sizes.get(&chromosome.chrom).unwrap() as i32;
+                        npy_meta_data_map.insert(
+                            chr_name,
+                            HashMap::from([
+                                ("stepsize".to_string(), stepsize),
+                                ("reported_chrom_size".to_string(), current_chrom_size),
+                            ]),
+                        );
+                    }
+
+                    for location in vec_count_type.iter() {
+
+                        let temp_meta_file_name = format!("{}{}.{}", bwfileheader, *location, "meta");
+
+                        if let Ok(file) = File::open(&temp_meta_file_name) {
+
+                            let reader = BufReader::new(file);
+
+                            for line in reader.lines() {
+                                let line = line.unwrap();
+                                let parts: Vec<&str> = line.split_whitespace().collect();
+                                if parts.len() >= 3 {
+                                    let chrom = parts[1].split('=')
+                                        .nth(1)
+                                        .expect("Processing npy metadata file: Missing chromosome in line");
+                                    let start_str = parts[2].split('=')
+                                        .nth(1)
+                                        .expect("Processing npy metadata file: Missing start position in line");
+                                    let starting_position: i32 = start_str.parse().expect("Processing npy metadata file: Invalid start position");
+
+                                    if let Some(current_chr_data) = npy_meta_data_map.get_mut(chrom) {
+                                        current_chr_data.insert((*location.to_string()).parse().unwrap(), starting_position);
+                                    }
+                                }
+                            }
+                            // Remove the file after it is used.
+                            let path = std::path::Path::new(&temp_meta_file_name);
+                            let _ = remove_file(path).unwrap();
+                        }
+
+                    }
+                    //write combined metadata as json
+                    let json_string = serde_json::to_string_pretty(&npy_meta_data_map).unwrap();
+                    let combined_npy_meta_file_path = format!("{}{}.{}", bwfileheader, "npy_meta", "json");
+                    let mut file = File::create(combined_npy_meta_file_path).unwrap();
+                    file.write_all(json_string.as_bytes()).unwrap();
+
                 }
                 _ => {}
             }

--- a/gtars/src/uniwig/mod.rs
+++ b/gtars/src/uniwig/mod.rs
@@ -191,7 +191,7 @@ pub fn run_uniwig(matches: &ArgMatches) {
 }
 
 /// Ensures that the start position is at a minimum equal to `1`
-fn clamped_start_position(start: i32, smoothsize: i32, wig_shift:i32) -> i32 {
+fn clamped_start_position(start: i32, smoothsize: i32, wig_shift: i32) -> i32 {
     std::cmp::max(1, start - smoothsize + wig_shift)
 }
 /// Ensure that the start position is at a minimum equal to `0`
@@ -221,7 +221,6 @@ pub fn uniwig_main(
         .num_threads(num_threads as usize)
         .build()
         .unwrap();
-
 
     // Determine Input File Type
     let input_filetype = FileType::from_str(filetype.to_lowercase().as_str());
@@ -319,7 +318,7 @@ pub fn uniwig_main(
                                                     clamped_start_position(
                                                         primary_start.0,
                                                         smoothsize,
-                                                        1 //must shift wiggle starts and core by 1 since it is 1 based
+                                                        1, //must shift wiggle starts and core by 1 since it is 1 based
                                                     ),
                                                     stepsize,
                                                     current_chrom_size,
@@ -449,7 +448,7 @@ pub fn uniwig_main(
                                                     clamped_start_position(
                                                         primary_end.0,
                                                         smoothsize,
-                                                        0
+                                                        0,
                                                     ),
                                                     stepsize,
                                                     meta_data_file_names[1].clone(),
@@ -468,7 +467,7 @@ pub fn uniwig_main(
                                                     clamped_start_position(
                                                         primary_end.0,
                                                         smoothsize,
-                                                        0
+                                                        0,
                                                     ),
                                                     stepsize,
                                                     meta_data_file_names[1].clone(),
@@ -520,7 +519,7 @@ pub fn uniwig_main(
                                                     &core_results.0,
                                                     file_name.clone(),
                                                     chrom_name.clone(),
-                                                    clamped_start_position(primary_start.0, 0,1), //starts are 1 based must be shifted by 1
+                                                    clamped_start_position(primary_start.0, 0, 1), //starts are 1 based must be shifted by 1
                                                     stepsize,
                                                     current_chrom_size,
                                                 );
@@ -589,9 +588,9 @@ pub fn uniwig_main(
                         );
                     }
                 }
-                "npy" =>{
+                "npy" => {
                     // populate hashmap for the npy meta data
-                    for chromosome in final_chromosomes.iter(){
+                    for chromosome in final_chromosomes.iter() {
                         let chr_name = chromosome.chrom.clone();
                         let current_chrom_size =
                             *chrom_sizes.get(&chromosome.chrom).unwrap() as i32;
@@ -605,27 +604,32 @@ pub fn uniwig_main(
                     }
 
                     for location in vec_count_type.iter() {
-
-                        let temp_meta_file_name = format!("{}{}.{}", bwfileheader, *location, "meta");
+                        let temp_meta_file_name =
+                            format!("{}{}.{}", bwfileheader, *location, "meta");
 
                         if let Ok(file) = File::open(&temp_meta_file_name) {
-
                             let reader = BufReader::new(file);
 
                             for line in reader.lines() {
                                 let line = line.unwrap();
                                 let parts: Vec<&str> = line.split_whitespace().collect();
                                 if parts.len() >= 3 {
-                                    let chrom = parts[1].split('=')
-                                        .nth(1)
-                                        .expect("Processing npy metadata file: Missing chromosome in line");
+                                    let chrom = parts[1].split('=').nth(1).expect(
+                                        "Processing npy metadata file: Missing chromosome in line",
+                                    );
                                     let start_str = parts[2].split('=')
                                         .nth(1)
                                         .expect("Processing npy metadata file: Missing start position in line");
-                                    let starting_position: i32 = start_str.parse().expect("Processing npy metadata file: Invalid start position");
+                                    let starting_position: i32 = start_str.parse().expect(
+                                        "Processing npy metadata file: Invalid start position",
+                                    );
 
-                                    if let Some(current_chr_data) = npy_meta_data_map.get_mut(chrom) {
-                                        current_chr_data.insert((*location.to_string()).parse().unwrap(), starting_position);
+                                    if let Some(current_chr_data) = npy_meta_data_map.get_mut(chrom)
+                                    {
+                                        current_chr_data.insert(
+                                            (*location.to_string()).parse().unwrap(),
+                                            starting_position,
+                                        );
                                     }
                                 }
                             }
@@ -633,14 +637,13 @@ pub fn uniwig_main(
                             let path = std::path::Path::new(&temp_meta_file_name);
                             let _ = remove_file(path).unwrap();
                         }
-
                     }
                     //write combined metadata as json
                     let json_string = serde_json::to_string_pretty(&npy_meta_data_map).unwrap();
-                    let combined_npy_meta_file_path = format!("{}{}.{}", bwfileheader, "npy_meta", "json");
+                    let combined_npy_meta_file_path =
+                        format!("{}{}.{}", bwfileheader, "npy_meta", "json");
                     let mut file = File::create(combined_npy_meta_file_path).unwrap();
                     file.write_all(json_string.as_bytes()).unwrap();
-
                 }
                 _ => {}
             }

--- a/gtars/src/uniwig/mod.rs
+++ b/gtars/src/uniwig/mod.rs
@@ -34,7 +34,6 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use tokio::runtime;
-use serde_json;
 
 pub mod cli;
 pub mod counting;
@@ -249,17 +248,9 @@ pub fn uniwig_main(
         }
     };
 
-    let mut npy_meta_data: HashMap<String, HashMap<String, i32>> = HashMap::new();
-    let mut arc_npy_meta_data = Arc::new(Mutex::new(npy_meta_data));
-    let mut chromosome_data_clone = Arc::clone(&arc_npy_meta_data);
-
     match input_filetype {
         //BED AND NARROWPEAK WORKFLOW
         Ok(FileType::BED) | Ok(FileType::NARROWPEAK) => {
-            // Pare down chromosomes if necessary
-            let mut final_chromosomes =
-                get_final_chromosomes(&input_filetype, filepath, &chrom_sizes, score);
-
             // Some housekeeping depending on output type
             let og_output_type = output_type; // need this later for conversion
             let mut output_type = output_type;
@@ -267,25 +258,9 @@ pub fn uniwig_main(
                 output_type = "bedGraph" // we must create bedgraphs first before creating bigwig files
             }
 
-            if output_type == "npy"{
-                // populate hashmap for the npy meta data
-                let mut arc_npy_meta_data_locked =  arc_npy_meta_data.lock().unwrap();
-                for chromosome in final_chromosomes.iter(){
-                    let chr_name = chromosome.chrom.clone();
-                    let current_chrom_size =
-                        *chrom_sizes.get(&chromosome.chrom).unwrap() as i32;
-
-                    arc_npy_meta_data_locked.insert(
-                        chr_name,
-                        HashMap::from([
-                            ("stepsize".to_string(), stepsize),
-                            ("reported_chrom_size".to_string(), current_chrom_size),
-                        ]),
-                    );
-
-                }
-
-            }
+            // Pare down chromosomes if necessary
+            let mut final_chromosomes =
+                get_final_chromosomes(&input_filetype, filepath, &chrom_sizes, score);
 
             let bar = ProgressBar::new(final_chromosomes.len() as u64);
 
@@ -373,7 +348,6 @@ pub fn uniwig_main(
                                                     "{}{}_{}.{}",
                                                     bwfileheader, chrom_name, "start", output_type
                                                 );
-
                                                 write_to_npy_file(
                                                     &count_result.0,
                                                     file_name.clone(),
@@ -382,8 +356,8 @@ pub fn uniwig_main(
                                                         primary_start.0,
                                                         smoothsize,
                                                     ),
-                                                    &mut chromosome_data_clone,
-                                                    "start",
+                                                    stepsize,
+                                                    meta_data_file_names[0].clone(),
                                                 );
                                             }
                                             _ => {
@@ -400,8 +374,8 @@ pub fn uniwig_main(
                                                         primary_start.0,
                                                         smoothsize,
                                                     ),
-                                                    &mut chromosome_data_clone,
-                                                    "start",
+                                                    stepsize,
+                                                    meta_data_file_names[0].clone(),
                                                 );
                                             }
                                         }
@@ -475,8 +449,8 @@ pub fn uniwig_main(
                                                         smoothsize,
                                                         0
                                                     ),
-                                                    &mut chromosome_data_clone,
-                                                    "end",
+                                                    stepsize,
+                                                    meta_data_file_names[1].clone(),
                                                 );
                                             }
                                             _ => {
@@ -494,8 +468,8 @@ pub fn uniwig_main(
                                                         smoothsize,
                                                         0
                                                     ),
-                                                    &mut chromosome_data_clone,
-                                                    "end",
+                                                    stepsize,
+                                                    meta_data_file_names[1].clone(),
                                                 );
                                             }
                                         }
@@ -562,8 +536,8 @@ pub fn uniwig_main(
                                                         primary_start.0,
                                                         0,
                                                     ),
-                                                    &mut chromosome_data_clone,
-                                                    "core",
+                                                    stepsize,
+                                                    meta_data_file_names[2].clone(),
                                                 );
                                             }
                                             _ => {
@@ -580,8 +554,8 @@ pub fn uniwig_main(
                                                         primary_start.0,
                                                         0,
                                                     ),
-                                                    &mut chromosome_data_clone,
-                                                    "core",
+                                                    stepsize,
+                                                    meta_data_file_names[2].clone(),
                                                 );
                                             }
                                         }
@@ -612,14 +586,6 @@ pub fn uniwig_main(
                             &final_chromosomes,
                         );
                     }
-                }
-                "npy" => {
-                    //write combined metadata
-                    let json_string = serde_json::to_string_pretty(&npy_meta_data).unwrap();
-                    let combined_npy_meta_file_path = format!("{}{}.{}", bwfileheader, "npy_meta", "json");
-                    let mut file = File::create(combined_npy_meta_file_path).unwrap();
-                    file.write_all(json_string.as_bytes()).unwrap();
-
                 }
                 _ => {}
             }

--- a/gtars/src/uniwig/writing.rs
+++ b/gtars/src/uniwig/writing.rs
@@ -8,20 +8,16 @@ use std::fs::{create_dir_all, remove_file, File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use std::{fs, io};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
-/// Write output to npy files AND update the meta_data hashmap
+/// Write output to npy files
 pub fn write_to_npy_file(
     counts: &[u32],
     filename: String,
     chromname: String,
     start_position: i32,
-    npy_meta_data_map: &mut Arc<Mutex<HashMap<String, HashMap<String, i32>>>>,
-    out_selection: &str,
+    stepsize: i32,
+    metafilename: String,
 ) {
-    let mut chromosome_data_guard = npy_meta_data_map.lock().unwrap();
-
     // For future reference `&Vec<u32>` is a SLICE and thus we must use the `to_vec` function below when creating an array
     // https://users.rust-lang.org/t/why-does-std-to-vec-exist/45893/9
 
@@ -29,11 +25,27 @@ pub fn write_to_npy_file(
     let arr = Array::from_vec(counts.to_vec());
     let _ = write_npy(filename, &arr);
 
-    // Write to the metadata hashmap
-    if let Some(current_chr_data) =  chromosome_data_guard.get_mut(chromname.as_str()) {
-        current_chr_data.insert(out_selection.to_string(), start_position);
-    }
+    // Write to the metadata file.
+    // Note: there should be a single metadata file for starts, ends and core
 
+    let path = std::path::Path::new(&metafilename).parent().unwrap();
+    let _ = create_dir_all(path);
+
+    let mut file = OpenOptions::new()
+        .create(true) // Create the file if it doesn't exist
+        .append(true) // Append data to the existing file if it does exist
+        .open(metafilename)
+        .unwrap();
+
+    // The original wiggle file header. This can be anything we wish it to be. Currently space delimited.
+    let mut wig_header = "fixedStep chrom=".to_string()
+        + chromname.as_str()
+        + " start="
+        + start_position.to_string().as_str()
+        + " step="
+        + stepsize.to_string().as_str();
+    wig_header.push('\n');
+    file.write_all(wig_header.as_ref()).unwrap();
 }
 
 /// Write either combined bedGraph, wiggle files, and bed files

--- a/gtars/tests/data/out/_core.wig
+++ b/gtars/tests/data/out/_core.wig
@@ -1,9 +1,10 @@
-fixedStep chrom=chr1 start=2 step=1
+fixedStep chrom=chr1 start=3 step=1
 2
 2
 3
+4
 2
-1
+2
 2
 1
 1

--- a/gtars/tests/data/out/_end.wig
+++ b/gtars/tests/data/out/_end.wig
@@ -13,3 +13,4 @@ fixedStep chrom=chr1 start=5 step=1
 0
 0
 0
+0

--- a/gtars/tests/data/out/_start.wig
+++ b/gtars/tests/data/out/_start.wig
@@ -1,4 +1,4 @@
-fixedStep chrom=chr1 start=1 step=1
+fixedStep chrom=chr1 start=2 step=1
 2
 2
 3
@@ -7,6 +7,7 @@ fixedStep chrom=chr1 start=1 step=1
 2
 1
 1
+0
 0
 0
 0

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -673,12 +673,10 @@ mod tests {
 
         let tempbedpath = format!("{}{}", path_to_crate, "/tests/data/test5.bed");
         let combinedbedpath = tempbedpath.as_str();
-        let combinedbedpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy3.bed";
-        //let combinedbedpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/chr1415.bed";
+        //let combinedbedpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy4.bed";
 
         let chromsizerefpath = combinedbedpath;
-        let chromsizerefpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy.chrom.sizes";
-        //let chromsizerefpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/test.chrom.sizes";
+        //let chromsizerefpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy.chrom.sizes";
 
         let tempdir = tempfile::tempdir().unwrap();
         let path = PathBuf::from(&tempdir.path());
@@ -687,16 +685,16 @@ mod tests {
         let bwfileheader_path = path.into_os_string().into_string().unwrap();
         let bwfileheader = bwfileheader_path.as_str();
 
-        let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/npy_output/";
+        //let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/npy_output/";
         //let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/wig_output/";
 
-        let smoothsize: i32 = 10;
+        let smoothsize: i32 = 2;
         let output_type = "npy";
         //let output_type = "wig";
         let filetype = "bed";
         let num_threads = 6;
         let score = false;
-        let stepsize = 5;
+        let stepsize = 1;
         let zoom = 0;
         let vec_count_type = vec!["start", "end", "core"];
 

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -486,7 +486,6 @@ mod tests {
                 &chromosome.ends,
                 current_chrom_size,
                 stepsize,
-                0,
             );
         }
     }
@@ -507,7 +506,6 @@ mod tests {
                 current_chrom_size,
                 smooth_size,
                 stepsize,
-                0,
             );
         }
     }
@@ -675,8 +673,10 @@ mod tests {
 
         let tempbedpath = format!("{}{}", path_to_crate, "/tests/data/test5.bed");
         let combinedbedpath = tempbedpath.as_str();
+        //let combinedbedpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy4.bed";
 
         let chromsizerefpath = combinedbedpath;
+        //let chromsizerefpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy.chrom.sizes";
 
         let tempdir = tempfile::tempdir().unwrap();
         let path = PathBuf::from(&tempdir.path());
@@ -685,8 +685,12 @@ mod tests {
         let bwfileheader_path = path.into_os_string().into_string().unwrap();
         let bwfileheader = bwfileheader_path.as_str();
 
-        let smoothsize: i32 = 5;
+        //let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/npy_output/";
+        //let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/wig_output/";
+
+        let smoothsize: i32 = 2;
         let output_type = "npy";
+        //let output_type = "wig";
         let filetype = "bed";
         let num_threads = 6;
         let score = false;

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -673,10 +673,12 @@ mod tests {
 
         let tempbedpath = format!("{}{}", path_to_crate, "/tests/data/test5.bed");
         let combinedbedpath = tempbedpath.as_str();
-        //let combinedbedpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy4.bed";
+        let combinedbedpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy3.bed";
+        //let combinedbedpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/chr1415.bed";
 
         let chromsizerefpath = combinedbedpath;
-        //let chromsizerefpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy.chrom.sizes";
+        let chromsizerefpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy.chrom.sizes";
+        //let chromsizerefpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/test.chrom.sizes";
 
         let tempdir = tempfile::tempdir().unwrap();
         let path = PathBuf::from(&tempdir.path());
@@ -685,16 +687,16 @@ mod tests {
         let bwfileheader_path = path.into_os_string().into_string().unwrap();
         let bwfileheader = bwfileheader_path.as_str();
 
-        //let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/npy_output/";
+        let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/npy_output/";
         //let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/wig_output/";
 
-        let smoothsize: i32 = 2;
+        let smoothsize: i32 = 10;
         let output_type = "npy";
         //let output_type = "wig";
         let filetype = "bed";
         let num_threads = 6;
         let score = false;
-        let stepsize = 1;
+        let stepsize = 5;
         let zoom = 0;
         let vec_count_type = vec!["start", "end", "core"];
 

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -673,10 +673,8 @@ mod tests {
 
         let tempbedpath = format!("{}{}", path_to_crate, "/tests/data/test5.bed");
         let combinedbedpath = tempbedpath.as_str();
-        //let combinedbedpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy4.bed";
 
         let chromsizerefpath = combinedbedpath;
-        //let chromsizerefpath = "/home/drc/Downloads/unwig_testing_19dec2024/input/dummy.chrom.sizes";
 
         let tempdir = tempfile::tempdir().unwrap();
         let path = PathBuf::from(&tempdir.path());
@@ -685,12 +683,8 @@ mod tests {
         let bwfileheader_path = path.into_os_string().into_string().unwrap();
         let bwfileheader = bwfileheader_path.as_str();
 
-        //let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/npy_output/";
-        //let bwfileheader = "/home/drc/Downloads/unwig_testing_19dec2024/output/wig_output/";
-
         let smoothsize: i32 = 2;
         let output_type = "npy";
-        //let output_type = "wig";
         let filetype = "bed";
         let num_threads = 6;
         let score = false;


### PR DESCRIPTION
Fixes #64 
Adds enhancement #65 

For #64, note that the start and core wiggles will be shifted by 1 since we are converting from bed files(0 based) to wiggles (1 based). The npy files are not shifted so the start and core positions will be 1 less than the wiggle counter parts.

However, because a bed file's end positions are 1 based, no shifting is done for the ends. Therefore, the npy and wig start positions for the end files should be the same.