### PR TITLE
potential solution for skipping sort

### DIFF
--- a/gtars/src/uniwig/cli.rs
+++ b/gtars/src/uniwig/cli.rs
@@ -95,6 +95,13 @@ pub fn create_uniwig_cli() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("skip-sort")
+                .long("skip-sort")
+                .short('k')
+                .help("Skip sorting starts and ends during reading of bed files.")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("no-bamshift")
                 .long("no-bamshift")
                 .short('a')

--- a/gtars/src/uniwig/mod.rs
+++ b/gtars/src/uniwig/mod.rs
@@ -157,6 +157,9 @@ pub fn run_uniwig(matches: &ArgMatches) {
         .expect("requires int value");
 
     let score = matches.get_one::<bool>("score").unwrap_or_else(|| &false);
+
+    let skip = matches.get_one::<bool>("skip-sort").unwrap_or_else(|| &false);
+
     let bam_shift = matches
         .get_one::<bool>("no-bamshift")
         .unwrap_or_else(|| &true);
@@ -186,6 +189,7 @@ pub fn run_uniwig(matches: &ArgMatches) {
         *debug,
         *bam_shift,
         *bam_scale,
+        *skip,
     )
     .expect("Uniwig failed.");
 }
@@ -215,6 +219,7 @@ pub fn uniwig_main(
     debug: bool,
     bam_shift: bool,
     bam_scale: f32,
+    skip_sort: bool,
 ) -> Result<(), Box<dyn Error>> {
     // Must create a Rayon thread pool in which to run our iterators
     let pool = rayon::ThreadPoolBuilder::new()
@@ -254,7 +259,7 @@ pub fn uniwig_main(
         Ok(FileType::BED) | Ok(FileType::NARROWPEAK) => {
             // Pare down chromosomes if necessary
             let mut final_chromosomes =
-                get_final_chromosomes(&input_filetype, filepath, &chrom_sizes, score);
+                get_final_chromosomes(&input_filetype, filepath, &chrom_sizes, score, skip_sort);
 
             // Some housekeeping depending on output type
             let og_output_type = output_type; // need this later for conversion

--- a/gtars/src/uniwig/reading.rs
+++ b/gtars/src/uniwig/reading.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 /// Reads combined bed file from a given path.
 /// Returns Vec of Chromosome struct
-pub fn read_bed_vec(combinedbedpath: &str) -> Vec<Chromosome> {
+pub fn read_bed_vec(combinedbedpath: &str, skip_sort: bool,) -> Vec<Chromosome> {
     let default_score = 1; // this will later be used for the count, which, by default, was originally = 1
     let path = Path::new(combinedbedpath);
 
@@ -59,8 +59,10 @@ pub fn read_bed_vec(combinedbedpath: &str) -> Vec<Chromosome> {
         if String::from(parsed_chr.trim()) != chrom {
             // If the parsed chrom is not the same as the current, sort, and then push to vector
             // then reset chromosome struct using the newest parsed_chr
-            chromosome.starts.sort_unstable();
-            chromosome.ends.sort_unstable();
+            if !skip_sort {
+                chromosome.starts.sort_unstable();
+                chromosome.ends.sort_unstable();
+            }
 
             chromosome_vec.push(chromosome.clone());
 
@@ -75,9 +77,11 @@ pub fn read_bed_vec(combinedbedpath: &str) -> Vec<Chromosome> {
         chromosome.ends.push((parsed_end, default_score));
     }
 
-    // Is this final sort and push actually necessary?
-    chromosome.starts.sort_unstable();
-    chromosome.ends.sort_unstable();
+    if !skip_sort {
+        // Is this final sort and push actually necessary?
+        chromosome.starts.sort_unstable();
+        chromosome.ends.sort_unstable();
+    }
     chromosome_vec.push(chromosome.clone());
 
     println!("Reading Bed file complete.");

--- a/gtars/src/uniwig/utils.rs
+++ b/gtars/src/uniwig/utils.rs
@@ -52,18 +52,19 @@ pub fn get_final_chromosomes(
     filepath: &str,
     chrom_sizes: &std::collections::HashMap<String, u32>,
     score: bool,
+    skip_sort: bool,
 ) -> Vec<Chromosome> {
     let chromosomes: Vec<Chromosome> = match ft {
-        Ok(FileType::BED) => read_bed_vec(filepath),
+        Ok(FileType::BED) => read_bed_vec(filepath, skip_sort),
         Ok(FileType::NARROWPEAK) => {
             if score {
                 println!("FileType is NarrowPeak and Score = True...Counting based on Score");
                 read_narrow_peak_vec(filepath) // if score flag enabled, this will attempt to read narrowpeak scores
             } else {
-                read_bed_vec(filepath)
+                read_bed_vec(filepath, skip_sort)
             }
         }
-        _ => read_bed_vec(filepath),
+        _ => read_bed_vec(filepath, skip_sort),
     };
 
     let num_chromosomes = chromosomes.len();

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -1044,7 +1044,8 @@ mod tests {
         let path = PathBuf::from(&tempdir.path());
 
         // For some reason, you cannot chain .as_string() to .unwrap() and must create a new line.
-        let bwfileheader_path = path.into_os_string().into_string().unwrap();
+        let mut bwfileheader_path = path.into_os_string().into_string().unwrap();
+        bwfileheader_path.push_str("/final/");
         let bwfileheader = bwfileheader_path.as_str();
 
         let smoothsize: i32 = 1;

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -443,10 +443,10 @@ mod tests {
 
     #[rstest]
     fn test_read_bed_vec(path_to_bed_file: &str, path_to_bed_file_gzipped: &str) {
-        let result1 = read_bed_vec(path_to_bed_file);
+        let result1 = read_bed_vec(path_to_bed_file, false);
         assert_eq!(result1.len(), 20);
 
-        let result2 = read_bed_vec(path_to_bed_file_gzipped);
+        let result2 = read_bed_vec(path_to_bed_file_gzipped, false);
         assert_eq!(result2.len(), 20);
     }
 
@@ -512,7 +512,7 @@ mod tests {
 
     #[rstest]
     fn test_read_bed_vec_length(path_to_sorted_small_bed_file: &str) {
-        let chromosomes: Vec<Chromosome> = read_bed_vec(path_to_sorted_small_bed_file);
+        let chromosomes: Vec<Chromosome> = read_bed_vec(path_to_sorted_small_bed_file, false);
         let num_chromosomes = chromosomes.len();
 
         assert_eq!(num_chromosomes, 5);
@@ -567,6 +567,7 @@ mod tests {
             false,
             true,
             1.0,
+            false
         )
         .expect("Uniwig main failed!");
 
@@ -613,6 +614,7 @@ mod tests {
             false,
             true,
             1.0,
+            false
         )
         .expect("Uniwig main failed!");
 
@@ -660,6 +662,7 @@ mod tests {
             false,
             true,
             1.0,
+            false
         )
         .expect("Uniwig main failed!");
 
@@ -707,6 +710,7 @@ mod tests {
             false,
             true,
             1.0,
+            false
         )
         .expect("Uniwig main failed!");
         Ok(())
@@ -773,6 +777,7 @@ mod tests {
             false,
             true,
             1.0,
+            false
         );
 
         assert!(result.is_ok());
@@ -841,6 +846,7 @@ mod tests {
             false,
             true,
             1.0,
+            false
         );
 
         assert!(result.is_ok());
@@ -955,6 +961,7 @@ mod tests {
             false,
             true,
             1.0,
+            false
         );
 
         assert!(result.is_ok());
@@ -1064,6 +1071,7 @@ mod tests {
             false,
             true,
             1.0,
+            false
         )
         .expect("Uniwig main failed!");
 
@@ -1110,6 +1118,7 @@ mod tests {
             false,
             true,
             1.0,
+            false
         )
         .expect("Uniwig main failed!");
 


### PR DESCRIPTION
@ClaudeHu try this branch and see if it:
a. shortens time significantly,
b. provides the same answer for your presorted bed files

The original C++ implementation of uniwig does sort the starts and ends in memory regardless of the sort flag being set.