### PR TITLE
Allow commented lines in fragment files.

### DIFF
--- a/gtars/src/scoring/fragment_scoring.rs
+++ b/gtars/src/scoring/fragment_scoring.rs
@@ -45,6 +45,10 @@ pub fn region_scoring_from_fragments(
         for line in reader.lines() {
             let line = line?;
 
+            if line.starts_with('#') {
+                continue;
+            }
+
             // convert to fragment and then get new positions of start and end
             let fragment = Fragment::from_str(&line)?;
 


### PR DESCRIPTION
Allow commented lines in fragment files as CellRanger-ATAC/CellRangerARC puts some commented lines at the start of the file.