### PR TITLE
0.2.1 release

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtars-py"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtars-py"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bindings/r/src/rust/Cargo.toml
+++ b/bindings/r/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'gtars-r'
-version = '0.2.0'
+version = '0.2.1'
 edition = '2021'
 
 [lib]

--- a/bindings/r/src/rust/Cargo.toml
+++ b/bindings/r/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'gtars-r'
-version = '0.1.2'
+version = '0.2.0'
 edition = '2021'
 
 [lib]

--- a/gtars/Cargo.toml
+++ b/gtars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtars"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "Performance-critical tools to manipulate, analyze, and process genomic interval data. Primarily focused on building tools for geniml - our genomic machine learning python package."
 license = "MIT"

--- a/gtars/Cargo.toml
+++ b/gtars/Cargo.toml
@@ -24,7 +24,7 @@ noodles = { version = "0.83.0", features = ["bam", "sam", "bgzf"] }
 bstr = "1.10.0"
 rayon = "1.10.0"
 indicatif = "0.17.8"
-bigtools = "0.5.4"
+bigtools = "0.5.5"
 tokio = "1.40.0"
 os_pipe = "1.2.1"
 glob = "0.3.1"

--- a/gtars/Cargo.toml
+++ b/gtars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtars"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Performance-critical tools to manipulate, analyze, and process genomic interval data. Primarily focused on building tools for geniml - our genomic machine learning python package."
 license = "MIT"

--- a/gtars/docs/changelog.md
+++ b/gtars/docs/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] 
+- allow comments at the beginning of fragment files
+- bump bigtools to 0.5.5, fixing [#74](https://github.com/databio/gtars/issues/74) and [#77](https://github.com/databio/gtars/issues/77)
+
 ## [0.2.0] 
 - add position shift workflow for bam to bw (was previously added for bam to bed)
 - add scaling argument for bam to bw workflow [#53](https://github.com/databio/gtars/issues/53)

--- a/gtars/src/scoring/fragment_scoring.rs
+++ b/gtars/src/scoring/fragment_scoring.rs
@@ -45,6 +45,10 @@ pub fn region_scoring_from_fragments(
         for line in reader.lines() {
             let line = line?;
 
+            if line.starts_with('#') {
+                continue;
+            }
+
             // convert to fragment and then get new positions of start and end
             let fragment = Fragment::from_str(&line)?;
 

--- a/gtars/src/uniwig/mod.rs
+++ b/gtars/src/uniwig/mod.rs
@@ -728,6 +728,7 @@ fn process_bam(
     // pre-process chromosomes that are actually in the bam file BEFORE spawning threads.
     for chromosome in list_of_valid_chromosomes.iter() {
         let region = chromosome.parse().unwrap();
+        //TODO if no .bai file exists, the below line will fail and won't properly tell you WHY it failed, issue #57
         let mut reader = bam::io::indexed_reader::Builder::default()
             .build_from_path(filepath)
             .unwrap();

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -1037,7 +1037,8 @@ mod tests {
         let path = PathBuf::from(&tempdir.path());
 
         // For some reason, you cannot chain .as_string() to .unwrap() and must create a new line.
-        let bwfileheader_path = path.into_os_string().into_string().unwrap();
+        let mut bwfileheader_path = path.into_os_string().into_string().unwrap();
+        bwfileheader_path.push_str("/final/");
         let bwfileheader = bwfileheader_path.as_str();
 
         let smoothsize: i32 = 1;


### PR DESCRIPTION
Point release which primarily bumps bigtools to v 0.5.0 and should subsequently fix #74 and #77 

Also closes #84 