### PR TITLE
Migrate to `upload-artifact@v4`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,9 +36,9 @@ jobs:
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-linux-${{ matrix.target }}
           path: ./bindings/python/dist
 
   windows:
@@ -60,9 +60,9 @@ jobs:
           sccache: 'true'
           working-directory: ./bindings/python
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-windows-${{ matrix.target }}
           path: ./bindings/python/dist
 
   macos:
@@ -83,9 +83,9 @@ jobs:
           sccache: 'true'
           working-directory: ./bindings/python
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos-${{ matrix.target }}
           path: ./bindings/python/dist
 
   sdist:
@@ -99,9 +99,9 @@ jobs:
           args: --out dist
           working-directory: ./bindings/python
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-sdist
           path: ./bindings/python/dist
 
   release:
@@ -113,9 +113,9 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, windows, macos, sdist]
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
           path: ./bindings/python/dist
       - name: List contents
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: wheels-*
           path: ./bindings/python/dist
       - name: List contents
         run: |


### PR DESCRIPTION
Hot fix to resolve #86 which is blocking the release of new python bindings