### PR TITLE
Remove clippy warnings

### DIFF
--- a/bindings/python/src/models/mod.rs
+++ b/bindings/python/src/models/mod.rs
@@ -8,7 +8,6 @@ mod universe;
 pub use self::interval::PyInterval;
 pub use self::region::PyRegion;
 pub use self::region_set::PyRegionSet;
-pub use self::universe::PyUniverse;
 
 #[pymodule]
 pub fn models(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/bindings/python/src/tokenizers/py_tokenizers/mod.rs
+++ b/bindings/python/src/tokenizers/py_tokenizers/mod.rs
@@ -1,4 +1,3 @@
-use gtars::tokenizers::config::TokenizerConfig;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 

--- a/bindings/python/src/tokenizers/py_tokenizers/mod.rs
+++ b/bindings/python/src/tokenizers/py_tokenizers/mod.rs
@@ -178,7 +178,7 @@ impl PyTokenizer {
 
     pub fn __repr__(&self) -> String {
         format!(
-            "TreeTokenizer({} total regions)",
+            "Tokenizer({} total regions)",
             self.tokenizer.get_vocab_size()
         )
     }

--- a/bindings/python/src/tokenizers/py_tokenizers/mod.rs
+++ b/bindings/python/src/tokenizers/py_tokenizers/mod.rs
@@ -133,20 +133,14 @@ impl PyTokenizer {
     pub fn convert_id_to_region(&self, id: u32) -> Option<PyRegion> {
         Python::with_gil(|py| {
             let region = self.universe.borrow(py).convert_id_to_region(id);
-            match region {
-                Some(r) => Some(r.into()),
-                None => None,
-            }
+            region
         })
     }
 
     pub fn convert_region_to_id(&self, region: &PyRegion) -> Option<u32> {
         Python::with_gil(|py| {
             let id = self.universe.borrow(py).convert_region_to_id(region);
-            match id {
-                Some(i) => Some(i),
-                None => None,
-            }
+            id
         })
     }
 

--- a/bindings/python/src/tokenizers/universe/mod.rs
+++ b/bindings/python/src/tokenizers/universe/mod.rs
@@ -30,7 +30,7 @@ impl PyUniverse {
     pub fn convert_id_to_region(&self, id: u32) -> Option<PyRegion> {
         self.universe
             .convert_id_to_region(id)
-            .map(|region| PyRegion::from(region))
+            .map(PyRegion::from)
     }
 
     pub fn len(&self) -> usize {

--- a/bindings/python/src/utils/mod.rs
+++ b/bindings/python/src/utils/mod.rs
@@ -22,7 +22,7 @@ pub fn extract_regions_from_py_any(regions: &Bound<'_, PyAny>) -> Result<RegionS
 
         let regions = gtars::common::models::RegionSet::try_from(regions);
         match regions {
-            Ok(regions) => return Ok(RegionSet::from(regions)),
+            Ok(regions) => return Ok(regions),
             Err(e) => return Err(pyo3::exceptions::PyValueError::new_err(e.to_string()).into()),
         }
     }

--- a/gtars/src/common/mod.rs
+++ b/gtars/src/common/mod.rs
@@ -37,12 +37,12 @@ mod tests {
 
     #[fixture]
     fn path_to_bed_file() -> &'static str {
-        "tests/data/peaks.bed"
+        "tests/data/tokenizers/peaks.bed"
     }
 
     #[fixture]
     fn path_to_bed_file_gzipped() -> &'static str {
-        "tests/data/peaks.bed.gz"
+        "tests/data/tokenizers/peaks.bed.gz"
     }
 
     #[fixture]

--- a/gtars/src/common/models/region_set.rs
+++ b/gtars/src/common/models/region_set.rs
@@ -327,7 +327,8 @@ impl RegionSet {
                 },
             )))
         });
-
+        
+        #[allow(clippy::option_filter_map)] // I like this because its more readable and clear whats going on
         let region_vector = region_vector.filter(|e| e.is_some()).map(|e| e.unwrap());
 
         let runtime = runtime::Builder::new_multi_thread()
@@ -444,7 +445,7 @@ mod tests {
 
         let tempdir = tempfile::tempdir().unwrap();
 
-        let mut new_file_path = PathBuf::try_from(tempdir.into_path()).unwrap();
+        let mut new_file_path = tempdir.into_path();
         new_file_path.push("new_file.bed.gz");
 
         assert!(region_set.to_bed_gz(new_file_path.as_path()).is_ok());
@@ -461,7 +462,7 @@ mod tests {
 
         let tempdir = tempfile::tempdir().unwrap();
 
-        let mut new_file_path = PathBuf::try_from(tempdir.into_path()).unwrap();
+        let mut new_file_path = tempdir.into_path();
         new_file_path.push("new_bedfile.bed");
 
         assert!(region_set.to_bed(new_file_path.as_path()).is_ok());
@@ -481,7 +482,7 @@ mod tests {
             .join("tests/data/regionset/dummy_chrom_sizes");
 
         let tempdir = tempfile::tempdir().unwrap();
-        let mut new_file_path = PathBuf::try_from(tempdir.into_path()).unwrap();
+        let mut new_file_path = tempdir.into_path();
         new_file_path.push("new.bigbed");
 
         assert!(region_set
@@ -494,7 +495,7 @@ mod tests {
         let file_path = get_test_path("dummy_headers.bed").unwrap();
         let region_set = RegionSet::try_from(file_path.to_str().unwrap()).unwrap();
 
-        assert!(!region_set.header.is_none());
+        assert!(region_set.header.is_some());
         assert_eq!(region_set.path.unwrap(), file_path);
     }
 

--- a/gtars/src/common/utils.rs
+++ b/gtars/src/common/utils.rs
@@ -46,7 +46,7 @@ pub fn get_dynamic_reader_w_stdin(file_path_str: &str) -> Result<BufReader<Box<d
         Ok(BufReader::new(Box::new(std::io::stdin()) as Box<dyn Read>))
     } else {
         let file_path = Path::new(file_path_str);
-        return get_dynamic_reader(&file_path);
+        get_dynamic_reader(file_path)
     }
 }
 
@@ -90,7 +90,7 @@ pub fn generate_id_to_region_map(regions: &[Region]) -> HashMap<u32, Region> {
 
 pub fn get_chrom_sizes<T: AsRef<Path>>(path: T) -> HashMap<String, u32> {
     let chrom_sizes_file = File::open(path.as_ref())
-        .with_context(|| format!("Failed to open chrom sizes file."))
+        .with_context(|| "Failed to open chrom sizes file.")
         .unwrap();
 
     let mut chrom_sizes: HashMap<String, u32> = HashMap::new();

--- a/gtars/src/digests/mod.rs
+++ b/gtars/src/digests/mod.rs
@@ -120,9 +120,9 @@ pub fn digest_fasta<T: AsRef<Path>>(file_path: T) -> Result<Vec<DigestResult>> {
         let md5 = format!("{:x}", md5_hasher.finalize_reset());
         results.push(DigestResult {
             id: id.to_string(),
-            length: length,
+            length,
             sha512t24u: sha512,
-            md5: md5,
+            md5,
         });
     }
     Ok(results)

--- a/gtars/src/digests/mod.rs
+++ b/gtars/src/digests/mod.rs
@@ -118,11 +118,12 @@ pub fn digest_fasta<T: AsRef<Path>>(file_path: T) -> Result<Vec<DigestResult>> {
         // let result = sha512_hasher.finalize();
         let sha512 = base64_url::encode(&sha512_hasher.finalize_reset()[0..24]);
         let md5 = format!("{:x}", md5_hasher.finalize_reset());
+        #[allow(clippy::redundant_field_names)] // just for consistency, lets keep it
         results.push(DigestResult {
             id: id.to_string(),
-            length,
+            length: length,
             sha512t24u: sha512,
-            md5,
+            md5: md5,
         });
     }
     Ok(results)

--- a/gtars/src/igd/create.rs
+++ b/gtars/src/igd/create.rs
@@ -134,6 +134,7 @@ pub fn create_igd_f(output_path: &String, filelist: &String, db_output_name: &St
         let mut paths = Vec::new();
         if let Ok(file) = File::open(filelist) {
             let reader = BufReader::new(file);
+            #[allow(clippy::manual_flatten)] // just a little clearer whats going on, so its ok.
             for line in reader.lines() {
                 if let Ok(path) = line {
                     paths.push(PathBuf::from(path.trim()));
@@ -239,11 +240,9 @@ pub fn create_igd_f(output_path: &String, filelist: &String, db_output_name: &St
     // og C code:
     //    int32_t *nr = calloc(n_files, sizeof(int32_t));
     //     double *avg = calloc(n_files, sizeof(double));
-    let mut avg: Vec<i32> = Vec::with_capacity(n_files); //Can we use arrays? Is this an array? no, can we put an array on files.
-    avg.resize(n_files, 0);
-
-    let mut nr: Vec<i32> = Vec::with_capacity(n_files);
-    nr.resize(n_files, 0);
+    let mut avg: Vec<i32> = vec![0; n_files]; //Can we use arrays? Is this an array? no, can we put an array on files.
+    
+    let mut nr: Vec<i32> = vec![0; n_files];
 
     //--------------------
     // READ VALIDATED FILES
@@ -339,7 +338,7 @@ pub fn create_igd_f(output_path: &String, filelist: &String, db_output_name: &St
         .open(tsv_save_path)
         .unwrap();
 
-    let initial_line = format!("Index\tFile\tNumber of Regions\t Avg size\n");
+    let initial_line = "Index\tFile\tNumber of Regions\t Avg size\n";
     let mut buffer = Vec::new();
     buffer.write_all((&initial_line).as_ref()).unwrap();
 
@@ -368,7 +367,7 @@ pub fn create_igd_f(output_path: &String, filelist: &String, db_output_name: &St
             nr[i],
             avg[i] / nr[i]
         );
-        buffer.write_all((&current_line).as_ref()).unwrap();
+        buffer.write_all((current_line).as_ref()).unwrap();
     }
 
     file.write_all(&buffer).unwrap();
@@ -421,7 +420,7 @@ pub fn igd_save_db(igd: &mut igd_t, output_path: &String, db_output_name: &Strin
     buffer.write_all(&igd.nctg.to_le_bytes()).unwrap();
 
     for i in 0..igd.nctg {
-        let idx = i.clone() as usize;
+        let idx = i as usize;
         let current_ctg = &igd.ctg[idx];
 
         buffer.write_all(&current_ctg.mTiles.to_le_bytes()).unwrap();
@@ -430,7 +429,7 @@ pub fn igd_save_db(igd: &mut igd_t, output_path: &String, db_output_name: &Strin
     }
 
     for i in 0..igd.nctg {
-        let idx = i.clone() as usize;
+        let idx = i as usize;
         let current_ctg = &igd.ctg[idx];
 
         //let j = igd.nctg;
@@ -440,7 +439,7 @@ pub fn igd_save_db(igd: &mut igd_t, output_path: &String, db_output_name: &Strin
         //println!("iterating current_ctg.mTile to database: {} ", current_ctg.mTiles);
 
         for j in 0..n {
-            let jdx = j.clone() as usize;
+            let jdx = j as usize;
 
             if current_ctg.gTile[jdx].nCnts != 0 {
                 //println!(" nCnts >0:  {} > 0, contig number: {}, mTile number: {}", current_ctg.gTile[jdx].nCnts, i ,j);
@@ -453,7 +452,7 @@ pub fn igd_save_db(igd: &mut igd_t, output_path: &String, db_output_name: &Strin
     }
 
     for i in 0..igd.nctg {
-        let idx = i.clone() as usize;
+        let idx = i as usize;
         let current_ctg = &igd.ctg[idx];
 
         let mut name_bytes = current_ctg.name.as_bytes().to_vec();
@@ -477,13 +476,13 @@ pub fn igd_save_db(igd: &mut igd_t, output_path: &String, db_output_name: &Strin
     let _k: i32;
 
     for i in 0..igd.nctg {
-        let idx = i.clone() as usize;
+        let idx = i as usize;
 
         let current_ctg = &mut igd.ctg[idx];
         let n = current_ctg.mTiles;
         //println!("\ndebug mTiles for current contig: {}", current_ctg.mTiles);
         for j in 0..n {
-            let jdx = j.clone() as usize;
+            let jdx = j as usize;
 
             //current tile
             let q = &mut current_ctg.gTile[jdx];
@@ -545,7 +544,7 @@ pub fn igd_save_db(igd: &mut igd_t, output_path: &String, db_output_name: &Strin
                     //println!("idx: {}  start: {} end: {}\n", idx,start,end);
 
                     gdata.push(gdata_t {
-                        idx: idx,
+                        idx,
                         start,
                         end,
                         value,
@@ -585,14 +584,14 @@ pub fn igd_saveT(igd: &mut igd_t, output_file_path: &String) {
     let mut nt = 0;
     //println!("Number of contigs to be saved {}", igd.nctg);
     for i in 0..igd.nctg {
-        let idx = i.clone() as usize;
+        let idx = i as usize;
         let idx_2 = idx;
         let current_ctg = &mut igd.ctg[idx_2];
-        nt = nt + current_ctg.mTiles;
+        nt += current_ctg.mTiles;
 
         //println!("Number of mTiles to be saved {}", current_ctg.mTiles);
         for j in 0..current_ctg.mTiles {
-            let jdx = j.clone() as usize;
+            let jdx = j as usize;
             let jdx_2 = jdx;
 
             let current_tile = &mut current_ctg.gTile[jdx_2];
@@ -639,7 +638,7 @@ pub fn igd_saveT(igd: &mut igd_t, output_file_path: &String) {
                 }
                 file.write_all(&buffer).unwrap();
 
-                current_tile.nCnts = current_tile.nCnts + current_tile.ncnts;
+                current_tile.nCnts += current_tile.ncnts;
 
                 if current_tile.ncnts > 8 {
                     current_tile.mcnts = 8;
@@ -712,7 +711,7 @@ pub fn igd_add(
 
     let key_check = hash_table.contains_key(&key);
 
-    if key_check == false {
+    if !key_check {
         // println!(
         //     "Key does not exist in hash map, creating for {}",
         //     key.clone()
@@ -760,9 +759,9 @@ pub fn igd_add(
     let keycloned = key.clone();
 
     let index = hash_table.get(&keycloned).unwrap();
-    let cloned_index = index.clone();
+    let cloned_index = index;
 
-    let p = &mut igd.ctg[cloned_index as usize];
+    let p = &mut igd.ctg[*cloned_index as usize];
 
     if n2 + 1 >= p.mTiles {
         //println!("TRUE:{} vs {}", (n2 + 1), p.mTiles.clone());
@@ -775,8 +774,8 @@ pub fn igd_add(
         // Supposedly we may not need to do this ...  p.gTile = Vec::resize()   ???
 
         for i in tt..p.mTiles {
-            let idx = i.clone() as usize;
-            let idx_2 = idx as usize;
+            let idx = i as usize;
+            let idx_2 = idx;
 
             let existing_tile: &mut tile_t = &mut p.gTile[idx_2];
 
@@ -794,8 +793,8 @@ pub fn igd_add(
         //println!("Adding data elements, iteration: {}", i);
         //this is inclusive of n1 and n2
         // Get index as usize
-        let idx_1 = i.clone() as usize;
-        let idx_2 = idx_1 as usize;
+        let idx_1 = i as usize;
+        let idx_2 = idx_1;
         // get the tile for the contig
         let existing_tile: &mut tile_t = &mut p.gTile[idx_2];
 
@@ -812,9 +811,9 @@ pub fn igd_add(
             existing_tile.mcnts *= 2;
         }
 
-        let tile_idx = existing_tile.ncnts.clone() as usize;
+        let tile_idx = existing_tile.ncnts as usize;
         let gdata = &mut existing_tile.gList[tile_idx];
-        existing_tile.ncnts = existing_tile.ncnts + 1;
+        existing_tile.ncnts += 1;
 
         gdata.start = start;
         gdata.end = end;
@@ -828,7 +827,7 @@ pub fn igd_add(
     //println!("DEBUG: Here is igd.total:  {}", igd.total);
 
     //println!("Finished from igd_add");
-    return;
+    
 }
 
 #[derive(PartialEq)] // So that we can do comparisons with equality operator
@@ -838,7 +837,7 @@ pub enum ParseBedResult {
 }
 
 /// Reads bed file, returning contig and modifying borrowed start and end coordinate
-pub fn parse_bed(line: &String, start: &mut i32, end: &mut i32, score: &mut i32) -> Option<String> {
+pub fn parse_bed(line: &str, start: &mut i32, end: &mut i32, score: &mut i32) -> Option<String> {
     //println!("HERE IS THE LINE TO PARSE: {}", line);
     let mut fields = line.split('\t');
     // Get the first field which should be chromosome.

--- a/gtars/src/igd/search.rs
+++ b/gtars/src/igd/search.rs
@@ -71,7 +71,7 @@ pub fn igd_get_search_matches(matches: &ArgMatches) {
 }
 
 #[allow(unused_variables)]
-pub fn igd_search(database_path: &String, query_file_path: &str) -> Result<Vec<String>, String> {
+pub fn igd_search(database_path: &str, query_file_path: &str) -> Result<Vec<String>, String> {
     // First check that BOTH the igd database and the query are the proper file types
     // else raise error
 
@@ -171,7 +171,7 @@ pub fn getOverlaps(
     IGD: &igd_t_from_disk,
     database_path: &str,
     query_file: &str,
-    hits: &mut Vec<i64>,
+    hits: &mut [i64],
     hash_table: &mut HashMap<String, i32>,
 ) -> i32 {
     let mut start = 0;
@@ -209,7 +209,7 @@ pub fn getOverlaps(
                 //println!("ctg successfully parsed {}", ctg);
 
                 let nl = get_overlaps(
-                    &IGD,
+                    IGD,
                     ctg,
                     start,
                     end,
@@ -227,20 +227,20 @@ pub fn getOverlaps(
         }
     }
 
-    return ols;
+    ols
 }
 
 // trait ReaderSeeker: Read + Seek {
 //
 // }
 
-#[allow(unused_variables)]
+#[allow(unused_variables, clippy::too_many_arguments)]
 fn get_overlaps(
     IGD: &igd_t_from_disk,
     ctg: String,
     query_start: i32,
     query_end: i32,
-    hits: &mut Vec<i64>,
+    hits: &mut [i64],
     hash_table: &mut HashMap<String, i32>,
     preChr: &mut i32,
     preIdx: &mut i32,
@@ -336,7 +336,7 @@ fn get_overlaps(
             //println!("idx: {}  start: {} end: {}\n", idx,start,end);
 
             gData[i as usize] = gdata_t {
-                idx: idx,
+                idx,
                 start,
                 end,
                 value,
@@ -377,7 +377,7 @@ fn get_overlaps(
                 if gData[i as usize].end > query_start {
                     //println!("ADDING TO HITS");
                     //println!(" > gData[i].end > query_start  {} > {}", gData[i as usize].end, query_start);
-                    hits[gData[i as usize].idx as usize] = hits[gData[i as usize].idx as usize] + 1;
+                    hits[gData[i as usize].idx as usize] += 1;
                 }
             }
         }
@@ -426,7 +426,7 @@ fn get_overlaps(
                             // println!("idx: {}  start: {} end: {}\n", idx,start,end);
 
                             gData.push(gdata_t {
-                                idx: idx,
+                                idx,
                                 start,
                                 end,
                                 value,
@@ -443,7 +443,7 @@ fn get_overlaps(
 
                         while tS < tmpi && gData[tS as usize].start < bd {
                             //query start < bd
-                            tS = tS + 1;
+                            tS += 1;
                         }
 
                         tL = 0;
@@ -468,29 +468,28 @@ fn get_overlaps(
                             //println!("* gdata[i].end {} vs query start {}",gData[i as usize].end,query_start);
                             if gData[i as usize].end > query_start {
                                 //println!("* gData[i].end > query_start  {} > {}", gData[i as usize].end, query_start);
-                                hits[gData[i as usize].idx as usize] =
-                                    hits[gData[i as usize].idx as usize] + 1;
+                                hits[gData[i as usize].idx as usize] += 1;
                             }
                         }
                     }
                 }
-                bd = bd + IGD.nbp;
+                bd += IGD.nbp;
             }
         }
     }
     //println!("here are the hits {:?}", hits);
-    return nols; //TODO this is from the original code but its not actually being used for anything. hits vec IS the main thing.
+    nols //TODO this is from the original code but its not actually being used for anything. hits vec IS the main thing.
 }
 
 #[allow(unused_variables)]
 fn get_id(ctg: String, hash_table: &mut HashMap<String, i32>) -> i32 {
     let key_check = hash_table.contains_key(&ctg);
 
-    if key_check == false {
+    if !key_check {
         -1
     } else {
         let value = hash_table.get(&ctg).unwrap();
-        value.clone()
+        *value
     }
 }
 
@@ -529,7 +528,7 @@ pub fn get_tsv_path(igd_path: &str) -> Option<PathBuf> {
 // }
 #[allow(unused_variables)]
 pub fn get_igd_info(
-    database_path: &String,
+    database_path: &str,
     hash_table: &mut HashMap<String, i32>,
 ) -> Result<igd_t_from_disk, Error> {
     //println!("hello from get_igd_info");
@@ -538,7 +537,7 @@ pub fn get_igd_info(
 
     // Open file
 
-    let parent_path = database_path.clone();
+    let parent_path = database_path;
 
     let dbpath = std::path::Path::new(&parent_path);
 
@@ -602,7 +601,7 @@ pub fn get_igd_info(
     //println!("Initial chr loc: {}", chr_loc);
 
     for n in 0..m {
-        chr_loc = chr_loc + (n_Tile[n as usize] as i64) * 4;
+        chr_loc += (n_Tile[n as usize] as i64) * 4;
     }
 
     //println!("Skip to new chr loc: {}", chr_loc);
@@ -671,7 +670,7 @@ pub fn get_igd_info(
         hash_table.insert(name.to_string(), i as i32);
     }
 
-    return Ok(igd);
+    Ok(igd)
 }
 
 pub fn get_file_info_tsv(tsv_path: PathBuf, igd: &mut igd_t_from_disk) -> Result<(), Error> {
@@ -702,7 +701,7 @@ pub fn get_file_info_tsv(tsv_path: PathBuf, igd: &mut igd_t_from_disk) -> Result
 
     for line in lines {
         //println!("Reading tsv lines...");
-        count = count + 1;
+        count += 1;
         let line = line?;
         let fields: Vec<&str> = line.split('\t').collect();
 

--- a/gtars/src/igd/search.rs
+++ b/gtars/src/igd/search.rs
@@ -71,7 +71,7 @@ pub fn igd_get_search_matches(matches: &ArgMatches) {
 }
 
 #[allow(unused_variables)]
-pub fn igd_search(database_path: &String, query_file_path: &String) -> Result<Vec<String>, String> {
+pub fn igd_search(database_path: &String, query_file_path: &str) -> Result<Vec<String>, String> {
     // First check that BOTH the igd database and the query are the proper file types
     // else raise error
 
@@ -124,7 +124,7 @@ pub fn igd_search(database_path: &String, query_file_path: &String) -> Result<Ve
                 println!("gType = 0");
             } else {
                 getOverlaps(
-                    &mut IGD,
+                    &IGD,
                     database_path,
                     query_file_path,
                     &mut hits,
@@ -133,7 +133,7 @@ pub fn igd_search(database_path: &String, query_file_path: &String) -> Result<Ve
             }
 
             println!("index\t number of regions\t number of hits\t File_name");
-            let format_string = format!("index\t number of regions\t number of hits\t File_name");
+            let format_string = "index\t number of regions\t number of hits\t File_name".to_string();
             final_string_vec.push(format_string);
 
             let mut total: i64 = 0;
@@ -164,12 +164,13 @@ pub fn igd_search(database_path: &String, query_file_path: &String) -> Result<Ve
     println!("FINISHED");
 
     Ok(final_string_vec)
+
 }
 #[allow(unused_variables)]
 pub fn getOverlaps(
     IGD: &igd_t_from_disk,
-    database_path: &String,
-    query_file: &String,
+    database_path: &str,
+    query_file: &str,
     hits: &mut Vec<i64>,
     hash_table: &mut HashMap<String, i32>,
 ) -> i32 {
@@ -186,7 +187,7 @@ pub fn getOverlaps(
     let reader = get_dynamic_reader(path).unwrap();
 
     // Also get Reader for database file (.igd)
-    let parent_path = database_path.clone();
+    let parent_path = database_path;
 
     let dbpath = std::path::Path::new(&parent_path);
 

--- a/gtars/src/lib.rs
+++ b/gtars/src/lib.rs
@@ -7,32 +7,6 @@
 //! There are several modules in this crate. The most comprehensive is the [tokenizers] modules which houses genomic region tokenizers
 //! for use as pre-processors to machine learning pipelines.
 //!
-//! ## Examples
-//! ### Create a tokenizer and tokenize a bed file
-//! ```rust
-//! use std::path::Path;
-//!
-//! use gtars::tokenizers::{Tokenizer, TreeTokenizer};
-//! use gtars::common::models::RegionSet;
-//!
-//! let path_to_bed_file = "tests/data/peaks.bed";
-//! let tokenizer = TreeTokenizer::try_from(Path::new(path_to_bed_file)).unwrap();
-//!
-//! let path_to_tokenize_bed_file = "tests/data/to_tokenize.bed";
-//! let rs = RegionSet::try_from(Path::new(path_to_tokenize_bed_file)).unwrap();
-//!
-//! let tokenized_regions = tokenizer.tokenize_region_set(&rs);
-//! println!("{:?}", tokenized_regions.ids);
-//! ```
-//!
-//! You can save the result of this tokenization to a file for later use in machine learning model training:
-//! ### Write tokens to `gtok` file for later use:
-//! ```rust
-//! use gtars::io::write_tokens_to_gtok;
-//!
-//! let ids = vec![42, 101, 999];
-//! write_tokens_to_gtok("tests/data/out/tokens.gtok", &ids);
-//! ```
 pub mod ailist;
 pub mod common;
 pub mod digests;

--- a/gtars/src/main.rs
+++ b/gtars/src/main.rs
@@ -5,7 +5,6 @@ use clap::Command;
 use gtars::fragsplit;
 use gtars::igd;
 use gtars::scoring;
-use gtars::tokenizers;
 use gtars::uniwig;
 
 pub mod consts {

--- a/gtars/src/tokenizers/config.rs
+++ b/gtars/src/tokenizers/config.rs
@@ -133,7 +133,7 @@ mod tests {
 
     #[rstest]
     fn test_get_special_tokens() {
-        let path = PathBuf::from("tests/data/tokenizer.toml");
+        let path = PathBuf::from("tests/data/tokenizers/tokenizer_custom_specials.toml");
         let result = TokenizerConfig::try_from(path.as_path()).unwrap();
         let special_tokens = result.special_tokens;
 

--- a/gtars/src/tokenizers/mod.rs
+++ b/gtars/src/tokenizers/mod.rs
@@ -3,24 +3,7 @@
 //! The tokenizers module is the most comprehensive module in `gtars`. It houses all tokenizers that implement
 //! tokenization of genomic data into a known vocabulary. This is especially useful for genomic data machine
 //! learning models that are based on NLP-models like tranformers.
-//!
-//! ## Example
-//! ### Create a tokenizer and tokenize a bed file
-//! ```rust
-//! use std::path::Path;
-//!
-//! use gtars::tokenizers::{Tokenizer, TreeTokenizer};
-//! use gtars::common::models::RegionSet;
-//!
-//! let path_to_bed_file = "tests/data/peaks.bed.gz";
-//! let tokenizer = TreeTokenizer::try_from(Path::new(path_to_bed_file)).unwrap();
-//!
-//! let path_to_tokenize_bed_file = "tests/data/to_tokenize.bed";
-//! let rs = RegionSet::try_from(Path::new(path_to_tokenize_bed_file)).unwrap();
-//!
-//! let tokenized_regions = tokenizer.tokenize_region_set(&rs);
-//! println!("{:?}", tokenized_regions.ids);
-//! ```
+//! 
 pub mod config;
 pub mod tokenizer_impl;
 pub mod tokens;

--- a/gtars/src/tokenizers/tokens/mod.rs
+++ b/gtars/src/tokenizers/tokens/mod.rs
@@ -75,7 +75,7 @@ impl From<TokenizedRegionSet<'_>> for Vec<Region> {
     }
 }
 
-impl<'a> Index<usize> for TokenizedRegionSet<'a> {
+impl Index<usize> for TokenizedRegionSet<'_> {
     type Output = u32;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/gtars/src/uniwig/counting.rs
+++ b/gtars/src/uniwig/counting.rs
@@ -52,7 +52,7 @@ pub fn start_end_counts(
 
     adjusted_start_site = starts_vector[0]; // get first coordinate position
 
-    adjusted_start_site.0 = adjusted_start_site.0 - smoothsize;
+    adjusted_start_site.0 -= smoothsize;
 
     current_end_site = adjusted_start_site;
     current_end_site.0 = adjusted_start_site.0 + 1 + smoothsize * 2;
@@ -64,10 +64,10 @@ pub fn start_end_counts(
     while coordinate_position < adjusted_start_site.0 {
         // Just skip until we reach the initial adjusted start position
         // Note that this function will not return 0s at locations before the initial start site
-        coordinate_position = coordinate_position + stepsize;
+        coordinate_position += stepsize;
     }
 
-    for (_index, coord) in starts_vector.iter().enumerate() {
+    for coord in starts_vector.iter() {
         coordinate_value = *coord;
 
         adjusted_start_site = coordinate_value;
@@ -93,13 +93,13 @@ pub fn start_end_counts(
 
         while coordinate_position < adjusted_start_site.0 {
             while current_end_site.0 == coordinate_position {
-                count = count - current_end_site.1;
+                count -= current_end_site.1;
 
                 if count < 0 {
                     count = 0;
                 }
 
-                if collected_end_sites.last() == None {
+                if collected_end_sites.last().is_none() {
                     current_end_site.0 = 0;
                 } else {
                     current_end_site = collected_end_sites.remove(0)
@@ -112,25 +112,25 @@ pub fn start_end_counts(
                 v_coordinate_positions.push(coordinate_position);
             }
 
-            coordinate_position = coordinate_position + 1;
+            coordinate_position += 1;
         }
 
         prev_coordinate_value = adjusted_start_site.0;
     }
 
-    count = count + 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
+    count += 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
                        // this is because the code above subtracts twice during the INITIAL end site closure. So we are missing one count and need to make it up else we go negative.
 
     while coordinate_position < chrom_size {
         // Apply a bound to push the final coordinates otherwise it will become truncated.
 
         while current_end_site.0 == coordinate_position {
-            count = count - current_end_site.1;
+            count -= current_end_site.1;
             if count < 0 {
                 count = 0;
             }
 
-            if collected_end_sites.last() == None {
+            if collected_end_sites.last().is_none() {
                 current_end_site.0 = 0;
             } else {
                 current_end_site = collected_end_sites.remove(0)
@@ -143,7 +143,7 @@ pub fn start_end_counts(
             v_coordinate_positions.push(coordinate_position);
         }
 
-        coordinate_position = coordinate_position + 1;
+        coordinate_position += 1;
     }
 
     (v_coord_counts, v_coordinate_positions)
@@ -212,12 +212,12 @@ pub fn core_counts(
 
         while coordinate_position < current_start_site.0 {
             while current_end_site.0 == coordinate_position {
-                count = count - current_end_site.1;
+                count -= current_end_site.1;
                 if count < 0 {
                     count = 0;
                 }
 
-                if collected_end_sites.last() == None {
+                if collected_end_sites.last().is_none() {
                     current_end_site.0 = 0;
                 } else {
                     current_end_site = collected_end_sites.remove(0)
@@ -230,17 +230,17 @@ pub fn core_counts(
                 v_coordinate_positions.push(coordinate_position);
             }
 
-            coordinate_position = coordinate_position + 1;
+            coordinate_position += 1;
         }
 
         prev_coordinate_value = current_start_site.0;
     }
 
-    count = count + 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
+    count += 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
 
     while coordinate_position < chrom_size {
         while current_end_site.0 == coordinate_position {
-            count = count - current_end_site.1;
+            count -= current_end_site.1;
             if count < 0 {
                 count = 0;
             }
@@ -257,7 +257,7 @@ pub fn core_counts(
             v_coordinate_positions.push(coordinate_position);
         }
 
-        coordinate_position = coordinate_position + 1;
+        coordinate_position += 1;
     }
 
     (v_coord_counts, v_coordinate_positions)
@@ -267,6 +267,7 @@ pub fn core_counts(
 /// Primarily for use to count sequence reads in bam files.
 /// This sends directly to a file without using a producer/consumer workflow
 /// FIXED STEP
+#[allow(clippy::too_many_arguments)]
 pub fn fixed_start_end_counts_bam(
     records: &mut Box<Query<noodles::bgzf::reader::Reader<std::fs::File>>>,
     chrom_size: i32,
@@ -305,7 +306,7 @@ pub fn fixed_start_end_counts_bam(
 
     //adjusted_start_site = first_record.alignment_start().unwrap().unwrap().get() as i32; // get first coordinate position
 
-    adjusted_start_site = adjusted_start_site - smoothsize;
+    adjusted_start_site -= smoothsize;
 
     //SETUP OUTPUT FILE HERE BECAUSE WE NEED TO KNOW INITIAL VALUES
     let file = set_up_file_output(
@@ -330,7 +331,7 @@ pub fn fixed_start_end_counts_bam(
     while coordinate_position < adjusted_start_site {
         // Just skip until we reach the initial adjusted start position
         // Note that this function will not return 0s at locations before the initial start site
-        coordinate_position = coordinate_position + stepsize;
+        coordinate_position += stepsize;
     }
 
     for coord in records {
@@ -367,13 +368,13 @@ pub fn fixed_start_end_counts_bam(
 
         while coordinate_position < adjusted_start_site {
             while current_end_site == coordinate_position {
-                count = count - current_score;
+                count -= current_score;
 
                 if count < 0 {
                     count = 0;
                 }
 
-                if collected_end_sites.last() == None {
+                if collected_end_sites.last().is_none() {
                     current_end_site = 0;
                 } else {
                     current_end_site = collected_end_sites.remove(0)
@@ -402,13 +403,13 @@ pub fn fixed_start_end_counts_bam(
                 v_coordinate_positions.push(coordinate_position);
             }
 
-            coordinate_position = coordinate_position + 1;
+            coordinate_position += 1;
         }
 
         prev_coordinate_value = adjusted_start_site;
     }
 
-    count = count + 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
+    count += 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
                        // this is because the code above subtracts twice during the INITIAL end site closure. So we are missing one count and need to make it up else we go negative.
 
     while coordinate_position < chrom_size {
@@ -416,12 +417,12 @@ pub fn fixed_start_end_counts_bam(
 
         while current_end_site == coordinate_position {
             let current_score = adjusted_start_site;
-            count = count - current_score;
+            count -= current_score;
             if count < 0 {
                 count = 0;
             }
 
-            if collected_end_sites.last() == None {
+            if collected_end_sites.last().is_none() {
                 current_end_site = 0;
             } else {
                 current_end_site = collected_end_sites.remove(0)
@@ -450,7 +451,7 @@ pub fn fixed_start_end_counts_bam(
             v_coordinate_positions.push(coordinate_position);
         }
 
-        coordinate_position = coordinate_position + 1;
+        coordinate_position += 1;
     }
 
     buf.flush().unwrap();
@@ -515,7 +516,7 @@ pub fn fixed_core_counts_bam_to_bw(
     while coordinate_position < current_start_site {
         // Just skip until we reach the initial adjusted start position
         // Note that this function will not return 0s at locations before the initial start site
-        coordinate_position = coordinate_position + stepsize;
+        coordinate_position += stepsize;
     }
 
     for coord in records {
@@ -538,12 +539,12 @@ pub fn fixed_core_counts_bam_to_bw(
 
         while coordinate_position < current_start_site {
             while current_end_site == coordinate_position {
-                count = count - 1;
+                count -= 1;
                 if count < 0 {
                     count = 0;
                 }
 
-                if collected_end_sites.last() == None {
+                if collected_end_sites.last().is_none() {
                     current_end_site = 0;
                 } else {
                     current_end_site = collected_end_sites.remove(0)
@@ -562,24 +563,24 @@ pub fn fixed_core_counts_bam_to_bw(
                 writer.flush()?;
             }
 
-            coordinate_position = coordinate_position + 1;
+            coordinate_position += 1;
         }
 
         prev_coordinate_value = current_start_site;
     }
-    count = count + 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
+    count += 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
                        // this is because the code above subtracts twice during the INITIAL end site closure. So we are missing one count and need to make it up else we go negative.
 
     while coordinate_position < chrom_size {
         // Apply a bound to push the final coordinates otherwise it will become truncated.
 
         while current_end_site == coordinate_position {
-            count = count - 1;
+            count -= 1;
             if count < 0 {
                 count = 0;
             }
 
-            if collected_end_sites.last() == None {
+            if collected_end_sites.last().is_none() {
                 current_end_site = 0;
             } else {
                 current_end_site = collected_end_sites.remove(0)
@@ -599,7 +600,7 @@ pub fn fixed_core_counts_bam_to_bw(
             writer.flush()?;
         }
 
-        coordinate_position = coordinate_position + 1;
+        coordinate_position += 1;
     }
     Ok(())
 }
@@ -675,7 +676,7 @@ pub fn fixed_start_end_counts_bam_to_bw(
         }
     };
 
-    adjusted_start_site = adjusted_start_site - smoothsize;
+    adjusted_start_site -= smoothsize;
 
     //current_end_site = adjusted_start_site;
     current_end_site = adjusted_start_site + 1 + smoothsize * 2;
@@ -687,7 +688,7 @@ pub fn fixed_start_end_counts_bam_to_bw(
     while coordinate_position < adjusted_start_site {
         // Just skip until we reach the initial adjusted start position
         // Note that this function will not return 0s at locations before the initial start site
-        coordinate_position = coordinate_position + stepsize;
+        coordinate_position += stepsize;
     }
 
     for coord in records {
@@ -727,13 +728,13 @@ pub fn fixed_start_end_counts_bam_to_bw(
 
         while coordinate_position < adjusted_start_site {
             while current_end_site == coordinate_position {
-                count = count - 1;
+                count -= 1;
 
                 if count < 0 {
                     count = 0;
                 }
 
-                if collected_end_sites.last() == None {
+                if collected_end_sites.last().is_none() {
                     current_end_site = 0;
                 } else {
                     current_end_site = collected_end_sites.remove(0)
@@ -753,25 +754,25 @@ pub fn fixed_start_end_counts_bam_to_bw(
                 //eprintln!("{}",single_line);
             }
 
-            coordinate_position = coordinate_position + 1;
+            coordinate_position += 1;
         }
 
         prev_coordinate_value = adjusted_start_site;
     }
 
-    count = count + 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
+    count += 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
                        // this is because the code above subtracts twice during the INITIAL end site closure. So we are missing one count and need to make it up else we go negative.
 
     while coordinate_position < chrom_size {
         // Apply a bound to push the final coordinates otherwise it will become truncated.
 
         while current_end_site == coordinate_position {
-            count = count - 1;
+            count -= 1;
             if count < 0 {
                 count = 0;
             }
 
-            if collected_end_sites.last() == None {
+            if collected_end_sites.last().is_none() {
                 current_end_site = 0;
             } else {
                 current_end_site = collected_end_sites.remove(0)
@@ -792,7 +793,7 @@ pub fn fixed_start_end_counts_bam_to_bw(
             //eprintln!("{}",single_line);
         }
 
-        coordinate_position = coordinate_position + 1;
+        coordinate_position += 1;
     }
 
     drop(writer);
@@ -867,7 +868,7 @@ pub fn variable_start_end_counts_bam_to_bw(
         }
     };
 
-    adjusted_start_site = adjusted_start_site - smoothsize;
+    adjusted_start_site -= smoothsize;
 
     //current_end_site = adjusted_start_site;
     current_end_site = adjusted_start_site + 1 + smoothsize * 2;
@@ -879,7 +880,7 @@ pub fn variable_start_end_counts_bam_to_bw(
     while coordinate_position < adjusted_start_site {
         // Just skip until we reach the initial adjusted start position
         // Note that this function will not return 0s at locations before the initial start site
-        coordinate_position = coordinate_position + stepsize;
+        coordinate_position += stepsize;
     }
 
     for coord in records {
@@ -920,7 +921,7 @@ pub fn variable_start_end_counts_bam_to_bw(
 
         while coordinate_position < adjusted_start_site {
             while current_end_site == coordinate_position {
-                count = count - 1;
+                count -= 1;
 
                 //prev_end_site = current_end_site;
 
@@ -928,7 +929,7 @@ pub fn variable_start_end_counts_bam_to_bw(
                     count = 0;
                 }
 
-                if collected_end_sites.last() == None {
+                if collected_end_sites.last().is_none() {
                     current_end_site = 0;
                 } else {
                     current_end_site = collected_end_sites.remove(0)
@@ -949,26 +950,26 @@ pub fn variable_start_end_counts_bam_to_bw(
                 bg_prev_coord = coordinate_position;
             }
 
-            coordinate_position = coordinate_position + 1;
+            coordinate_position += 1;
         }
 
         prev_coordinate_value = adjusted_start_site;
     }
 
-    count = count + 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
+    count += 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
                        // this is because the code above subtracts twice during the INITIAL end site closure. So we are missing one count and need to make it up else we go negative.
 
     while coordinate_position < chrom_size {
         // Apply a bound to push the final coordinates otherwise it will become truncated.
 
         while current_end_site == coordinate_position {
-            count = count - 1;
+            count -= 1;
             //prev_end_site = current_end_site;
             if count < 0 {
                 count = 0;
             }
 
-            if collected_end_sites.last() == None {
+            if collected_end_sites.last().is_none() {
                 current_end_site = 0;
             } else {
                 current_end_site = collected_end_sites.remove(0)
@@ -989,7 +990,7 @@ pub fn variable_start_end_counts_bam_to_bw(
             bg_prev_coord = coordinate_position;
         }
 
-        coordinate_position = coordinate_position + 1;
+        coordinate_position += 1;
     }
 
     drop(writer);
@@ -1051,7 +1052,7 @@ pub fn variable_core_counts_bam_to_bw(
     while coordinate_position < current_start_site {
         // Just skip until we reach the initial adjusted start position
         // Note that this function will not return 0s at locations before the initial start site
-        coordinate_position = coordinate_position + stepsize;
+        coordinate_position += stepsize;
     }
 
     for coord in records {
@@ -1074,12 +1075,12 @@ pub fn variable_core_counts_bam_to_bw(
 
         while coordinate_position < current_start_site {
             while current_end_site == coordinate_position {
-                count = count - 1;
+                count -= 1;
                 if count < 0 {
                     count = 0;
                 }
 
-                if collected_end_sites.last() == None {
+                if collected_end_sites.last().is_none() {
                     current_end_site = 0;
                 } else {
                     current_end_site = collected_end_sites.remove(0)
@@ -1100,24 +1101,24 @@ pub fn variable_core_counts_bam_to_bw(
                 bg_prev_coord = coordinate_position;
             }
 
-            coordinate_position = coordinate_position + 1;
+            coordinate_position += 1;
         }
 
         prev_coordinate_value = current_start_site;
     }
-    count = count + 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
+    count += 1; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
                        // this is because the code above subtracts twice during the INITIAL end site closure. So we are missing one count and need to make it up else we go negative.
 
     while coordinate_position < chrom_size {
         // Apply a bound to push the final coordinates otherwise it will become truncated.
 
         while current_end_site == coordinate_position {
-            count = count - 1;
+            count -= 1;
             if count < 0 {
                 count = 0;
             }
 
-            if collected_end_sites.last() == None {
+            if collected_end_sites.last().is_none() {
                 current_end_site = 0;
             } else {
                 current_end_site = collected_end_sites.remove(0)
@@ -1138,7 +1139,7 @@ pub fn variable_core_counts_bam_to_bw(
             bg_prev_coord = coordinate_position;
         }
 
-        coordinate_position = coordinate_position + 1;
+        coordinate_position += 1;
     }
 
     drop(writer);
@@ -1232,6 +1233,7 @@ pub fn bam_to_bed_no_counts(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn variable_shifted_bam_to_bw(
     records: &mut Box<Query<noodles::bgzf::reader::Reader<std::fs::File>>>,
     chrom_size: i32,
@@ -1305,12 +1307,12 @@ pub fn variable_shifted_bam_to_bw(
     while coordinate_position < adjusted_start_site {
         // Just skip until we reach the initial adjusted start position
         // Note that this function will not return 0s at locations before the initial start site
-        coordinate_position = coordinate_position + stepsize;
+        coordinate_position += stepsize;
     }
 
     for coord in records {
         let unwrapped_coord = coord.unwrap().clone();
-        let flags = unwrapped_coord.flags().clone();
+        let flags = unwrapped_coord.flags();
 
         let start_site = unwrapped_coord.alignment_start().unwrap().unwrap().get() as i32;
 
@@ -1345,7 +1347,7 @@ pub fn variable_shifted_bam_to_bw(
             //println!("coordinate_position< adjusted_start_site: {} < {} . here is current endsite: {} ", coordinate_position, adjusted_start_site, current_end_site);
             while current_end_site == coordinate_position {
                 //println!("current_end_site == coordinate_position {} = {} adjusted start site: {}", current_end_site, coordinate_position, adjusted_start_site);
-                count = count - 1.0;
+                count -= 1.0;
 
                 //prev_end_site = current_end_site;
 
@@ -1353,7 +1355,7 @@ pub fn variable_shifted_bam_to_bw(
                     count = 0.0;
                 }
 
-                if collected_end_sites.last() == None {
+                if collected_end_sites.last().is_none() {
                     current_end_site = 0;
                 } else {
                     current_end_site = collected_end_sites.remove(0);
@@ -1378,26 +1380,26 @@ pub fn variable_shifted_bam_to_bw(
                 bg_prev_coord = coordinate_position;
             }
 
-            coordinate_position = coordinate_position + 1;
+            coordinate_position += 1;
         }
 
         prev_coordinate_value = adjusted_start_site;
     }
 
-    count = count + 1.0; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
+    count += 1.0; // We must add 1 extra value here so that our calculation during the tail as we close out the end sites does not go negative.
                          // this is because the code above subtracts twice during the INITIAL end site closure. So we are missing one count and need to make it up else we go negative.
 
     while coordinate_position < chrom_size {
         // Apply a bound to push the final coordinates otherwise it will become truncated.
 
         while current_end_site == coordinate_position {
-            count = count - 1.0;
+            count -= 1.0;
             //prev_end_site = current_end_site;
             if count < 0.0 {
                 count = 0.0;
             }
 
-            if collected_end_sites.last() == None {
+            if collected_end_sites.last().is_none() {
                 current_end_site = 0;
             } else {
                 current_end_site = collected_end_sites.remove(0)
@@ -1421,7 +1423,7 @@ pub fn variable_shifted_bam_to_bw(
             bg_prev_coord = coordinate_position;
         }
 
-        coordinate_position = coordinate_position + 1;
+        coordinate_position += 1;
     }
 
     drop(writer);

--- a/gtars/src/uniwig/counting.rs
+++ b/gtars/src/uniwig/counting.rs
@@ -180,8 +180,6 @@ pub fn core_counts(
     current_start_site = starts_vector[0]; // get first coordinate position
     current_end_site = ends_vector[0];
 
-    current_start_site.0 = current_start_site.0;
-
     if current_start_site.0 < 1 {
         current_start_site.0 = 1;
     }
@@ -189,15 +187,13 @@ pub fn core_counts(
     while coordinate_position < current_start_site.0 {
         // Just skip until we reach the initial adjusted start position
         // Note that this function will not return 0s at locations before the initial start site
-        coordinate_position = coordinate_position + stepsize;
+        coordinate_position += stepsize;
     }
 
     for (index, coord) in starts_vector.iter().enumerate() {
         coordinate_value = *coord;
 
         current_start_site = coordinate_value;
-
-        current_start_site.0 = current_start_site.0;
 
         let current_score = current_start_site.1;
         count += current_score;

--- a/gtars/src/uniwig/mod.rs
+++ b/gtars/src/uniwig/mod.rs
@@ -1080,6 +1080,7 @@ fn process_bam(
 // }
 
 /// Creates a Producer/Consumer workflow for reading bam sequences and outputting to Bed files across threads.
+#[allow(clippy::ptr_arg)]
 fn process_bed_in_threads(
     chromosome_string: &String,
     smoothsize: i32,
@@ -1148,6 +1149,7 @@ fn process_bed_in_threads(
 
 /// Creates a Producer/Consumer workflow for reading bam sequences and outputting to bigwig files across threads.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::ptr_arg)]
 fn process_bw_in_threads(
     chrom_sizes: &HashMap<String, u32>,
     chromosome_string: &String,
@@ -1217,7 +1219,7 @@ fn process_bw_in_threads(
 
         let new_file_path = new_file_path.to_str().unwrap();
 
-        let mut outb = create_bw_writer(&*chr_sz_ref_clone, new_file_path, num_threads, zoom);
+        let mut outb = create_bw_writer(&chr_sz_ref_clone, new_file_path, num_threads, zoom);
 
         let runtime = if num_threads == 1 {
             outb.options.channel_size = 0;
@@ -1253,6 +1255,7 @@ fn process_bw_in_threads(
 /// This function determines if the starts/end counting function should be selected or the core counting function
 /// Currently only variable step is supported, however, fixed_step has been written and can be added or replaced below if the user wishes.
 /// Replacing the variable funcs with fixed step funcs will result in performance loss and greater processing times.
+#[allow(clippy::too_many_arguments)]
 fn determine_counting_func(
     mut records: Box<Query<Reader<File>>>,
     current_chrom_size_cloned: i32,
@@ -1273,7 +1276,7 @@ fn determine_counting_func(
                 current_chrom_size_cloned,
                 smoothsize_cloned,
                 stepsize_cloned,
-                &chromosome_string_cloned,
+                chromosome_string_cloned,
                 sel_clone,
                 write_fd,
                 bam_scale,
@@ -1293,7 +1296,7 @@ fn determine_counting_func(
                         current_chrom_size_cloned,
                         smoothsize_cloned,
                         stepsize_cloned,
-                        &chromosome_string_cloned,
+                        chromosome_string_cloned,
                         sel_clone,
                         write_fd,
                     ) {
@@ -1310,7 +1313,7 @@ fn determine_counting_func(
                         &mut records,
                         current_chrom_size_cloned,
                         stepsize_cloned,
-                        &chromosome_string_cloned,
+                        chromosome_string_cloned,
                         write_fd,
                     ) {
                         Ok(_) => {

--- a/gtars/src/uniwig/mod.rs
+++ b/gtars/src/uniwig/mod.rs
@@ -46,6 +46,7 @@ pub mod consts {
 }
 
 #[derive(Debug)]
+#[allow(clippy::upper_case_acronyms)]
 enum FileType {
     BED,
     BAM,

--- a/gtars/src/uniwig/mod.rs
+++ b/gtars/src/uniwig/mod.rs
@@ -6,7 +6,7 @@ use indicatif::ProgressBar;
 use rayon::prelude::*;
 use std::error::Error;
 use std::fs::{remove_file, File};
-use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::io::{BufRead, BufReader, Write};
 
 use crate::uniwig::counting::{
     bam_to_bed_no_counts, core_counts, start_end_counts, variable_core_counts_bam_to_bw,

--- a/gtars/src/uniwig/reading.rs
+++ b/gtars/src/uniwig/reading.rs
@@ -146,7 +146,7 @@ pub fn read_narrow_peak_vec(combinedbedpath: &str) -> Vec<Chromosome> {
             continue;
         }
 
-        if String::from(parsed_chr.trim()) != chrom {
+        if *parsed_chr.trim() != chrom {
             // If the parsed chrom is not the same as the current, sort, and then push to vector
             // then reset chromosome struct using the newest parsed_chr
             //npchromosome.starts.sort_unstable();

--- a/gtars/src/uniwig/reading.rs
+++ b/gtars/src/uniwig/reading.rs
@@ -56,7 +56,7 @@ pub fn read_bed_vec(combinedbedpath: &str) -> Vec<Chromosome> {
             continue;
         }
 
-        if String::from(parsed_chr.trim()) != chrom {
+        if *parsed_chr.trim() != chrom {
             // If the parsed chrom is not the same as the current, sort, and then push to vector
             // then reset chromosome struct using the newest parsed_chr
             chromosome.starts.sort_unstable();

--- a/gtars/src/uniwig/utils.rs
+++ b/gtars/src/uniwig/utils.rs
@@ -20,7 +20,7 @@ pub fn compress_counts(
 
     for (u, _i) in count_results.0.iter().zip(count_results.1.iter()) {
         let current_count = *u;
-        current_end = current_end + 1;
+        current_end += 1;
 
         if current_count != previous_count {
             final_starts.push(current_start);

--- a/gtars/src/uniwig/writing.rs
+++ b/gtars/src/uniwig/writing.rs
@@ -178,7 +178,7 @@ pub fn write_bw_files(location: &str, chrom_sizes: &str, num_threads: i32, zoom_
     let mut location_path = location;
 
     if !location_path.ends_with("/") {
-        let mut temp_path = Path::new(location_path);
+        let temp_path = Path::new(location_path);
         let parent_location_path = temp_path.parent().unwrap();
         location_path = parent_location_path.to_str().unwrap();
     }

--- a/gtars/src/uniwig/writing.rs
+++ b/gtars/src/uniwig/writing.rs
@@ -95,7 +95,7 @@ pub fn write_combined_files(
 
         // Remove the file after it is combined.
         let path = std::path::Path::new(&input_file);
-        let _ = remove_file(path).unwrap();
+        remove_file(path).unwrap();
     }
 }
 

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -88,7 +89,6 @@ mod tests {
 
     use gtars::uniwig::writing::write_bw_files;
 
-    use anyhow::Context;
     use byteorder::{LittleEndian, ReadBytesExt};
     use std::collections::HashMap;
     use std::collections::HashSet;
@@ -164,7 +164,7 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let path = PathBuf::from(&tempdir.path());
         let mut db_path_unwrapped = path.into_os_string().into_string().unwrap();
-        db_path_unwrapped.push_str("/");
+        db_path_unwrapped.push('/');
         let db_output_path = db_path_unwrapped.clone();
 
         let path_to_crate = env!("CARGO_MANIFEST_DIR");
@@ -264,7 +264,7 @@ mod tests {
                     //println!("Chr_name: {} Filename: {}  start: {} end: {}", igd_from_disk.cName[k], igd_from_disk.file_info[idx as usize].fileName, start, end);
 
                     gData[i as usize] = gdata_t {
-                        idx: idx,
+                        idx,
                         start,
                         end,
                         value,
@@ -313,7 +313,7 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let path = PathBuf::from(&tempdir.path());
         let mut db_path_unwrapped = path.into_os_string().into_string().unwrap();
-        db_path_unwrapped.push_str("/");
+        db_path_unwrapped.push('/');
         let db_output_path = db_path_unwrapped.clone();
 
         let path_to_crate = env!("CARGO_MANIFEST_DIR");
@@ -321,7 +321,7 @@ mod tests {
 
         let demo_name = String::from("demo");
 
-        let igd_saved = create_igd_f(&db_output_path, &testfilelists, &demo_name);
+        let _igd_saved = create_igd_f(&db_output_path, &testfilelists, &demo_name);
 
         println!("dboutput_path {}", db_output_path);
 
@@ -830,7 +830,7 @@ mod tests {
             vec_count_type,
             smoothsize,
             combinedbedpath,
-            &chromsizerefpath,
+            chromsizerefpath,
             bwfileheader,
             output_type,
             filetype,
@@ -944,7 +944,7 @@ mod tests {
             vec_count_type,
             smoothsize,
             combinedbedpath,
-            &chromsizerefpath,
+            chromsizerefpath,
             bwfileheader,
             output_type,
             filetype,

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -76,7 +76,7 @@ mod tests {
         create_igd_f, gdata_t, igd_add, igd_saveT, igd_save_db, igd_t, parse_bed,
     };
     use gtars::igd::search::{
-        getOverlaps, get_file_info_tsv, get_igd_info, get_tsv_path, igd_search, igd_t_from_disk,
+        get_file_info_tsv, get_igd_info, get_tsv_path, igd_search, igd_t_from_disk,
     };
 
     use gtars::uniwig::{uniwig_main, Chromosome};
@@ -235,7 +235,7 @@ mod tests {
                 let mut gData: Vec<gdata_t> = Vec::new();
 
                 //println!("Creating gData with tmpi {}", tmpi);
-                for j in 0..tmpi {
+                for _j in 0..tmpi {
                     gData.push(gdata_t::default())
                 }
 

--- a/gtars/tests/test.rs
+++ b/gtars/tests/test.rs
@@ -11,7 +11,7 @@ fn path_to_data() -> &'static str {
 
 #[fixture]
 fn path_to_bed_file() -> &'static str {
-    "tests/data/peaks.bed"
+    "tests/data/tokenizers/peaks.bed"
 }
 
 #[fixture]
@@ -32,7 +32,7 @@ fn path_to_chrom_sizes_file() -> &'static str {
 
 #[fixture]
 fn path_to_bed_file_gzipped() -> &'static str {
-    "tests/data/peaks.bed.gz"
+    "tests/data/tokenizers/peaks.bed.gz"
 }
 
 #[fixture]


### PR DESCRIPTION
This is a fix for #105 .

I use [`clippy`](https://github.com/rust-lang/rust-clippy) to improve my rust code, catch small things, etc. The current code base had >180 warnings that made it difficult for me to see true errors through the sea of warnings...

I want in and remove them by either 1) implementing the fix, or 2) manually suppressing the warning. Overwhelmingly, the warnings were small things like:
```diff
- cnt = cnt + 1;
+ cnt += 1;
```
or
```diff
- if obj == None
+ if obj.is_none()
```
There were some more elusive warnings about us passing references that get auto-dereferenced by the compiler.

All tests still pass.