### PR TITLE
Added calculation of file_digest to RegionSet struct

### DIFF
--- a/bindings/python/src/models/region_set.rs
+++ b/bindings/python/src/models/region_set.rs
@@ -53,6 +53,11 @@ impl PyRegionSet {
     }
 
     #[getter]
+    fn get_file_digest(&self) -> PyResult<String> {
+        Ok(self.regionset.file_digest())
+    }
+
+    #[getter]
     fn get_path(&self) -> PyResult<String> {
         Ok(self
             .regionset

--- a/bindings/python/src/tokenizers/mod.rs
+++ b/bindings/python/src/tokenizers/mod.rs
@@ -5,8 +5,8 @@ mod universe;
 use pyo3::prelude::*;
 
 use crate::tokenizers::py_tokenizers::PyTokenizer;
-use crate::tokenizers::universe::PyUniverse;
 use crate::tokenizers::tokens::PyTokenizedRegionSet;
+use crate::tokenizers::universe::PyUniverse;
 
 #[pymodule]
 pub fn tokenizers(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/bindings/python/src/tokenizers/py_tokenizers/mod.rs
+++ b/bindings/python/src/tokenizers/py_tokenizers/mod.rs
@@ -3,9 +3,9 @@ use pyo3::types::PyType;
 
 use anyhow::Result;
 
-use crate::tokenizers::universe::PyUniverse;
-use crate::tokenizers::tokens::PyTokenizedRegionSet;
 use crate::models::PyRegion;
+use crate::tokenizers::tokens::PyTokenizedRegionSet;
+use crate::tokenizers::universe::PyUniverse;
 use crate::utils::extract_regions_from_py_any;
 use gtars::tokenizers::Tokenizer;
 
@@ -17,7 +17,6 @@ pub struct PyTokenizer {
 
 #[pymethods]
 impl PyTokenizer {
-
     #[new]
     fn new(path: &str) -> Result<Self> {
         Python::with_gil(|py| {
@@ -169,19 +168,22 @@ impl PyTokenizer {
 
         Ok(tokenized.ids)
     }
-    
+
     fn decode(&self, ids: Vec<u32>) -> Result<Vec<PyRegion>> {
         Python::with_gil(|py| {
             let regions = ids
                 .iter()
-                .map(|id| self.universe.borrow(py).convert_id_to_token(*id).unwrap_or(
-                    PyRegion {
-                        chr: "chrUNK".to_string(),
-                        start: 0,
-                        end: 0,
-                        rest: None,
-                    }
-                ))
+                .map(|id| {
+                    self.universe
+                        .borrow(py)
+                        .convert_id_to_token(*id)
+                        .unwrap_or(PyRegion {
+                            chr: "chrUNK".to_string(),
+                            start: 0,
+                            end: 0,
+                            rest: None,
+                        })
+                })
                 .collect::<Vec<PyRegion>>();
             Ok(regions)
         })

--- a/bindings/python/src/tokenizers/universe/mod.rs
+++ b/bindings/python/src/tokenizers/universe/mod.rs
@@ -28,9 +28,7 @@ impl PyUniverse {
     }
 
     pub fn convert_id_to_token(&self, id: u32) -> Option<PyRegion> {
-        self.universe
-            .convert_id_to_token(id)
-            .map(PyRegion::from)
+        self.universe.convert_id_to_token(id).map(PyRegion::from)
     }
 
     pub fn len(&self) -> usize {

--- a/gtars/src/common/models/region_set.rs
+++ b/gtars/src/common/models/region_set.rs
@@ -289,6 +289,25 @@ impl RegionSet {
         bed_digest
     }
 
+    pub fn file_digest(&self) -> String {
+
+        let mut region_copy = self.clone();
+        region_copy.sort();
+
+        let mut buffer: String = String::new();
+        for region in region_copy.regions {
+            buffer.push_str(&format!("{}\n", region.as_string(),));
+        }
+
+        let mut hasher = Md5::new();
+
+        hasher.update(buffer);
+        let hash = hasher.finalize();
+        let file_digest: String = format!("{:x}", hash);
+
+        file_digest
+    }
+
     ///
     /// Save RegionSet as bigBed (binary version of bed file)
     ///
@@ -505,5 +524,14 @@ mod tests {
         let region_set = RegionSet::try_from(file_path.to_str().unwrap()).unwrap();
 
         assert!(!region_set.is_empty());
+    }
+
+    #[test]
+    fn test_file_digest() {
+        let file_path = get_test_path("dummy.narrowPeak").unwrap();
+        let region_set = RegionSet::try_from(file_path.to_str().unwrap()).unwrap();
+
+        assert_eq!(region_set.file_digest(), "6224c4d40832b3e0889250f061e01120");
+        assert_eq!(region_set.identifier(), "f0b2cf73383b53bd97ff525a0380f200")
     }
 }


### PR DESCRIPTION
We would like to calculate bed file digest of whole file, not just region. In this PR you can find new function that calculates this digest.

p.s.
I am sorting bed file before calculation of the digest, and because of that I am cloning RegionSet object. Is there a better way of doing it?