### PR TITLE
feat: iterator trait and improved ailist

### DIFF
--- a/gtars/src/common/models/interval.rs
+++ b/gtars/src/common/models/interval.rs
@@ -1,17 +1,13 @@
 // https://github.com/sstadick/rust-lapper/blob/7e3904daed85181f1faa39b15f51935f13945976/src/lib.rs#L92
-use num_traits::{
-    identities::zero,
-    PrimInt, Unsigned,
-};
+use num_traits::{identities::zero, PrimInt, Unsigned};
 use std::cmp::Ordering::{self};
-
 
 /// Represent a range from [start, end)
 /// Inclusive start, exclusive of end
 #[derive(Eq, Debug, Clone)]
 pub struct Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     pub start: I,
@@ -19,10 +15,9 @@ where
     pub val: T,
 }
 
-
 impl<I, T> Ord for Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     #[inline]
@@ -35,10 +30,9 @@ where
     }
 }
 
-
 impl<I, T> Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     /// Compute the intsect between two intervals
@@ -58,7 +52,7 @@ where
 
 impl<I, T> PartialOrd for Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     #[inline]
@@ -69,7 +63,7 @@ where
 
 impl<I, T> PartialEq for Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     #[inline]

--- a/gtars/src/overlap/ailist.rs
+++ b/gtars/src/overlap/ailist.rs
@@ -9,7 +9,7 @@ use crate::common::models::Interval;
 #[derive(Debug, Clone)]
 pub struct AiList<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     starts: Vec<I>,
@@ -23,7 +23,7 @@ where
 #[derive(Debug, Default)]
 struct DecomposeResult<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     /// Start positions.
@@ -40,7 +40,7 @@ where
 
 impl<I, T> DecomposeResult<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     /// Clear the contents of the [`DecomposeResult`], maintaining capacity.
@@ -66,7 +66,7 @@ where
 
 impl<I, T> Overlapper<I, T> for AiList<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     ///
@@ -163,7 +163,7 @@ where
 
 impl<I, T> AiList<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     fn decompose(
@@ -247,7 +247,7 @@ where
 pub struct IterFind<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
 {
     inner: &'a AiList<I, T>,
     header_list_idx: usize,
@@ -258,7 +258,7 @@ where
 
 impl<'a, I, T> IterFind<'a, I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync + 'a,
+    I: PrimInt + Unsigned + Clone + Send + Sync + 'a,
     T: Eq + Clone + Send + Sync,
 {
     fn new(ailist: &'a AiList<I, T>, start: I, stop: I) -> Self {
@@ -274,7 +274,7 @@ where
 
 impl<'a, I, T> Iterator for IterFind<'a, I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync + 'a,
 {
     type Item = &'a Interval<I, T>;

--- a/gtars/src/overlap/ailist.rs
+++ b/gtars/src/overlap/ailist.rs
@@ -1,11 +1,12 @@
+use std::mem::swap;
+
 use num_traits::{PrimInt, Unsigned};
 
-use crate::common::models::Interval;
 use super::Overlapper;
+use crate::common::models::Interval;
 
-///
 /// The Augmented Interval List (AiList), enumerates intersections between a query interval q and an interval set R.
-///
+#[derive(Debug, Clone)]
 pub struct AiList<I, T>
 where
     I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
@@ -15,17 +16,59 @@ where
     ends: Vec<I>,
     max_ends: Vec<I>,
     header_list: Vec<usize>,
-    data_list: Vec<T>,
+    stored_intervals: Vec<Interval<I, T>>,
 }
 
-type DecomposeResult<I, T> = (Vec<I>, Vec<I>, Vec<I>, Vec<T>, Vec<Interval<I, T>>);
+/// Storage for the intermediate results from [`AiList::decompose`].
+#[derive(Debug, Default)]
+struct DecomposeResult<I, T>
+where
+    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    T: Eq + Clone + Send + Sync,
+{
+    /// Start positions.
+    starts: Vec<I>,
+    /// End positions.
+    ends: Vec<I>,
+    /// The max end position seen up to this index.
+    max_ends: Vec<I>,
+    /// The associated Interval.
+    stored_intervals: Vec<Interval<I, T>>,
+    /// The remaining intervals to be decomposed.
+    l2: Vec<Interval<I, T>>,
+}
+
+impl<I, T> DecomposeResult<I, T>
+where
+    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    T: Eq + Clone + Send + Sync,
+{
+    /// Clear the contents of the [`DecomposeResult`], maintaining capacity.
+    fn clear(&mut self) {
+        self.starts.clear();
+        self.ends.clear();
+        self.max_ends.clear();
+        self.stored_intervals.clear();
+        self.l2.clear();
+    }
+
+    /// Create an empty [`DecomposeResult`] with the given `cap` capacity.
+    fn with_capacity(cap: usize) -> Self {
+        Self {
+            starts: Vec::with_capacity(cap),
+            ends: Vec::with_capacity(cap),
+            max_ends: Vec::with_capacity(cap),
+            stored_intervals: Vec::with_capacity(cap),
+            l2: Vec::with_capacity(cap),
+        }
+    }
+}
 
 impl<I, T> Overlapper<I, T> for AiList<I, T>
 where
     I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
-
     ///
     /// Create a new AIList struct
     ///
@@ -34,25 +77,37 @@ where
     ///
     /// # Returns
     /// - AIList struct
-    fn build(intervals: Vec<Interval<I, T>>) -> Self  where Self: Sized {
+    fn build(intervals: Vec<Interval<I, T>>) -> Self
+    where
+        Self: Sized,
+    {
         // in the future, clone and sort...
         let mut intervals = intervals;
         intervals.sort_by_key(|key| key.start);
 
-        let mut starts = Vec::new();
-        let mut ends = Vec::new();
-        let mut max_ends = Vec::new();
-        let mut data_list = Vec::new();
+        let mut starts = Vec::with_capacity(intervals.len());
+        let mut ends = Vec::with_capacity(intervals.len());
+        let mut max_ends = Vec::with_capacity(intervals.len());
+        let mut stored_intervals = Vec::with_capacity(intervals.len());
+
+        // Scratch space for construction
+        // The scratch vecs will get drained into the above final vectors, but the capacity
+        // in the scratch space will remain on each call, avoiding any additional allocations.
+        //
+        // Creating with cap of `intervals.len()` is overkill, but it means there will only every be the
+        // on allocation and prevents any possible re-allocs if a given sub-list is larger than the previous.
+        let mut results = DecomposeResult::with_capacity(intervals.len());
+
         let mut header_list = vec![0];
 
         loop {
-            let mut results = Self::decompose(&intervals, 10);
+            Self::decompose(&intervals, 10, &mut results);
 
-            starts.append(&mut results.0);
-            ends.append(&mut results.1);
-            max_ends.append(&mut results.2);
-            data_list.append(&mut results.3);
-            intervals = results.4;
+            starts.append(&mut results.starts);
+            ends.append(&mut results.ends);
+            max_ends.append(&mut results.max_ends);
+            stored_intervals.append(&mut results.stored_intervals);
+            swap(&mut intervals, &mut results.l2);
 
             if intervals.is_empty() {
                 break;
@@ -66,11 +121,11 @@ where
             ends,
             max_ends,
             header_list,
-            data_list,
+            stored_intervals,
         }
     }
 
-    fn find(&self, start: I, end: I) -> Vec<Interval<I,T>> {
+    fn find(&self, start: I, end: I) -> Vec<Interval<I, T>> {
         let mut results_list = Vec::new();
 
         for i in 0..(self.header_list.len() - 1) {
@@ -80,7 +135,7 @@ where
                 &self.starts[self.header_list[i]..self.header_list[i + 1]],
                 &self.ends[self.header_list[i]..self.header_list[i + 1]],
                 &self.max_ends[self.header_list[i]..self.header_list[i + 1]],
-                &self.data_list[self.header_list[i]..self.header_list[i + 1]],
+                &self.stored_intervals[self.header_list[i]..self.header_list[i + 1]],
             ));
         }
         // now do the last decomposed AiList
@@ -91,10 +146,18 @@ where
             &self.starts[self.header_list[i]..],
             &self.ends[self.header_list[i]..],
             &self.max_ends[self.header_list[i]..],
-            &self.data_list[self.header_list[i]..],
+            &self.stored_intervals[self.header_list[i]..],
         ));
 
         results_list
+    }
+
+    fn find_iter<'a>(
+        &'a self,
+        start: I,
+        stop: I,
+    ) -> Box<dyn Iterator<Item = &'a Interval<I, T>> + 'a> {
+        Box::new(IterFind::new(self, start, stop))
     }
 }
 
@@ -103,17 +166,12 @@ where
     I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
-
     fn decompose(
         intervals: &[Interval<I, T>],
         minimum_coverage_length: usize,
-    ) -> DecomposeResult<I, T> {
-        // look at the next minL*2 intervals
-        let mut starts = Vec::new();
-        let mut ends = Vec::new();
-        let mut max_ends = Vec::new();
-        let mut data_list = Vec::new();
-        let mut l2 = Vec::new();
+        scratch: &mut DecomposeResult<I, T>,
+    ) {
+        scratch.clear();
 
         for (index, interval) in intervals.iter().enumerate() {
             let mut count = 0;
@@ -128,26 +186,24 @@ where
                 }
             }
             if count >= minimum_coverage_length {
-                l2.push(Interval {
+                scratch.l2.push(Interval {
                     start: interval.start,
                     end: interval.end,
                     val: interval.val.clone(),
                 });
             } else {
-                starts.push(interval.start);
-                ends.push(interval.end);
-                data_list.push(interval.val.clone());
+                scratch.starts.push(interval.start);
+                scratch.ends.push(interval.end);
+                scratch.stored_intervals.push(interval.clone());
             }
         }
 
         let mut max: I = I::zero();
 
-        for end in ends.iter() {
+        for end in scratch.ends.iter() {
             max = if max > *end { max } else { *end };
-            max_ends.push(max);
+            scratch.max_ends.push(max);
         }
-
-        (starts, ends, max_ends, data_list, l2)
     }
 
     fn query_slice(
@@ -156,25 +212,22 @@ where
         starts: &[I],
         ends: &[I],
         max_ends: &[I],
-        data_list: &[T],
+        stored_intervals: &[Interval<I, T>],
     ) -> Vec<Interval<I, T>> {
         let mut results_list = Vec::new();
         let mut i = starts.partition_point(|&x| x < end);
 
         while i > 0 {
             i -= 1;
-            if start > ends[i] {
+            // maintain start inclusive, end exclusive
+            if start >= ends[i] {
                 //this means that there is no intersection
                 if start > max_ends[i] {
                     //there is no further intersection
                     return results_list;
                 }
             } else {
-                results_list.push(Interval {
-                    start: starts[i],
-                    end: ends[i],
-                    val: data_list[i].clone(),
-                })
+                results_list.push(stored_intervals[i].clone())
             }
         }
         results_list
@@ -188,20 +241,114 @@ where
         self.starts.is_empty()
     }
 }
+
+/// Find Iterator
+#[derive(Debug)]
+pub struct IterFind<'a, I, T>
+where
+    T: Eq + Clone + Send + Sync + 'a,
+    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+{
+    inner: &'a AiList<I, T>,
+    header_list_idx: usize,
+    list_idx: Option<usize>,
+    start: I,
+    stop: I,
+}
+
+impl<'a, I, T> IterFind<'a, I, T>
+where
+    I: PrimInt + Unsigned + Ord + Clone + Send + Sync + 'a,
+    T: Eq + Clone + Send + Sync,
+{
+    fn new(ailist: &'a AiList<I, T>, start: I, stop: I) -> Self {
+        Self {
+            inner: ailist,
+            header_list_idx: 0,
+            list_idx: None,
+            start,
+            stop,
+        }
+    }
+}
+
+impl<'a, I, T> Iterator for IterFind<'a, I, T>
+where
+    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    T: Eq + Clone + Send + Sync + 'a,
+{
+    type Item = &'a Interval<I, T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.header_list_idx < self.inner.header_list.len() {
+            let range = if self.header_list_idx == self.inner.header_list.len() - 1 {
+                // is last
+                self.inner.header_list[self.header_list_idx]..self.inner.starts.len()
+            } else {
+                self.inner.header_list[self.header_list_idx]
+                    ..self.inner.header_list[self.header_list_idx + 1]
+            };
+            let starts = &self.inner.starts[range.clone()];
+            let ends = &self.inner.ends[range.clone()];
+            let max_ends = &self.inner.max_ends[range.clone()];
+            let stored_intervalss = &self.inner.stored_intervals[range.clone()];
+
+            let i = if let Some(list_idx) = self.list_idx.as_mut() {
+                list_idx
+            } else {
+                self.list_idx = Some(starts.partition_point(|&x| x < self.stop));
+                self.list_idx.as_mut().unwrap()
+            };
+
+            while *i > 0 {
+                *i -= 1;
+                // maintain start inclusive, end exclusive
+                if self.start >= ends[*i] {
+                    // there is no further intersection, try the next header_list_idx
+                    if self.start > max_ends[*i] {
+                        break;
+                    }
+                } else {
+                    return Some(&stored_intervalss[*i]);
+                }
+            }
+            self.list_idx = None;
+            self.header_list_idx += 1;
+        }
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use pretty_assertions::{assert_eq, assert_ne};
-    use rstest::{rstest, fixture};
+    use rstest::{fixture, rstest};
 
     #[fixture]
     fn intervals() -> Vec<Interval<u32, &'static str>> {
         vec![
-            Interval { start: 1, end: 5, val: "a" },
-            Interval { start: 3, end: 7, val: "b" },
-            Interval { start: 6, end: 10, val: "c" },
-            Interval { start: 8, end: 12, val: "d" },
+            Interval {
+                start: 1,
+                end: 5,
+                val: "a",
+            },
+            Interval {
+                start: 3,
+                end: 7,
+                val: "b",
+            },
+            Interval {
+                start: 6,
+                end: 10,
+                val: "c",
+            },
+            Interval {
+                start: 8,
+                end: 12,
+                val: "d",
+            },
         ]
     }
 
@@ -214,7 +361,6 @@ mod tests {
 
     #[rstest]
     fn test_find_overlapping_intervals(intervals: Vec<Interval<u32, &'static str>>) {
-
         let ailist = AiList::build(intervals);
 
         // Query that overlaps with "a" and "b"
@@ -234,7 +380,6 @@ mod tests {
 
     #[rstest]
     fn test_find_no_overlap(intervals: Vec<Interval<u32, &'static str>>) {
-        
         let ailist = AiList::build(intervals);
 
         // Query outside all intervals
@@ -244,7 +389,6 @@ mod tests {
 
     #[rstest]
     fn test_empty_ailist() {
-
         let ailist: AiList<u32, &str> = AiList::build(vec![]);
 
         assert_eq!(ailist.len(), 0);
@@ -252,6 +396,152 @@ mod tests {
 
         let results = ailist.find(1, 2);
 
+        assert_eq!(results.is_empty(), true);
+    }
+
+    #[rstest]
+    fn test_find_iter_overlapping_intervals(intervals: Vec<Interval<u32, &'static str>>) {
+        let ailist = AiList::build(intervals);
+
+        // Query that overlaps with "a" and "b"
+        let results: Vec<&Interval<u32, &str>> = ailist.find_iter(2, 4).collect();
+        let vals: Vec<&str> = results.iter().map(|i| i.val).collect();
+        assert_eq!(vals.contains(&"a"), true);
+        assert_eq!(vals.contains(&"b"), true);
+        assert_eq!(vals.contains(&"c"), false);
+        assert_eq!(results.len(), 2);
+
+        // Query that overlaps with "c" and "d"
+        let results: Vec<&Interval<u32, &str>> = ailist.find_iter(9, 11).collect();
+        let vals: Vec<&str> = results.iter().map(|i| i.val).collect();
+        assert_eq!(vals.contains(&"c"), true);
+        assert_eq!(vals.contains(&"d"), true);
+        assert_eq!(vals.contains(&"a"), false);
+        assert_eq!(results.len(), 2);
+    }
+
+    #[rstest]
+    fn test_find_iter_no_overlap(intervals: Vec<Interval<u32, &'static str>>) {
+        let ailist = AiList::build(intervals);
+
+        // Query outside all intervals
+        let results: Vec<&Interval<u32, &str>> = ailist.find_iter(13, 15).collect();
+        assert_eq!(results.is_empty(), true);
+
+        // Query before all intervals
+        let results: Vec<&Interval<u32, &str>> = ailist.find_iter(0, 1).collect();
+        assert_eq!(results.is_empty(), true);
+    }
+
+    #[rstest]
+    fn test_find_iter_empty_ailist() {
+        let ailist: AiList<u32, &str> = AiList::build(vec![]);
+
+        let results: Vec<&Interval<u32, &str>> = ailist.find_iter(1, 2).collect();
+        assert_eq!(results.is_empty(), true);
+    }
+
+    #[rstest]
+    fn test_find_iter_matches_find(intervals: Vec<Interval<u32, &'static str>>) {
+        let ailist = AiList::build(intervals);
+
+        // Test multiple queries to ensure find_iter produces same results as find
+        let test_queries = vec![(2, 4), (5, 8), (9, 11), (0, 15), (7, 9)];
+
+        for (start, end) in test_queries {
+            let find_results = ailist.find(start, end);
+            let find_iter_results: Vec<&Interval<u32, &str>> =
+                ailist.find_iter(start, end).collect();
+
+            // Check that both methods return the same number of intervals
+            assert_eq!(
+                find_results.len(),
+                find_iter_results.len(),
+                "Mismatch in number of results for query ({}, {})",
+                start,
+                end
+            );
+
+            // Check that all intervals from find are present in find_iter results
+            for interval in &find_results {
+                assert!(
+                    find_iter_results.contains(&interval),
+                    "Interval {interval:?} from find() not found in find_iter() results",
+                );
+            }
+        }
+    }
+
+    #[rstest]
+    fn test_find_iter_single_interval() {
+        let intervals = vec![Interval {
+            start: 5,
+            end: 10,
+            val: "single",
+        }];
+        let ailist = AiList::build(intervals);
+
+        // Overlapping query
+        let results: Vec<&Interval<u32, &str>> = ailist.find_iter(6, 8).collect();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].val, "single");
+
+        // Non-overlapping query
+        let results: Vec<&Interval<u32, &str>> = ailist.find_iter(11, 15).collect();
+        assert_eq!(results.is_empty(), true);
+    }
+
+    #[rstest]
+    fn test_find_iter_complex_interval() {
+        let iv = |start: usize, end: usize| -> Interval<usize, ()> {
+            Interval {
+                start,
+                end,
+                val: (),
+            }
+        };
+        let intervals = vec![
+            iv(0, 30), // Span many ivs
+            iv(0, 10),
+            iv(0, 10),
+            iv(5, 15),
+            iv(5, 15),
+            iv(10, 20),
+            iv(10, 20),
+            iv(15, 25),
+            iv(15, 25),
+            iv(21, 22),
+            iv(22, 23),
+            iv(20, 30),
+            iv(20, 30),
+            iv(25, 100), // Span many ivs
+            iv(26, 27),
+            iv(27, 28),
+            iv(29, 30),
+            iv(30, 31),
+            iv(32, 33),
+            iv(50, 51),
+            iv(51, 52),
+            iv(52, 53),
+            iv(53, 54),
+            iv(55, 56),
+            iv(60, 61),
+            iv(70, 71),
+        ];
+
+        let ailist = AiList::build(intervals);
+        // Confirm we are at least iterating over header list values a bit.
+        assert_eq!(ailist.header_list.len(), 2);
+
+        // Overlapping query
+        let results: Vec<&Interval<usize, ()>> = ailist.find_iter(6, 8).collect();
+        assert_eq!(results.len(), 5);
+
+        let results: Vec<&Interval<usize, ()>> = ailist.find_iter(30, 35).collect();
+        assert_eq!(results.len(), 3);
+
+        // Non-overlapping query
+        let results: Vec<&Interval<usize, ()>> = ailist.find_iter(101, 150).collect();
         assert_eq!(results.is_empty(), true);
     }
 }

--- a/gtars/src/overlap/bits.rs
+++ b/gtars/src/overlap/bits.rs
@@ -9,7 +9,7 @@ use crate::common::models::Interval;
 #[derive(Debug, Clone)]
 pub struct Bits<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     /// List of intervals
@@ -28,7 +28,7 @@ where
 
 impl<I, T> Overlapper<I, T> for Bits<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     /// Create a new instance of Bits by passing in a vector of Intervals. This vector will
@@ -119,7 +119,7 @@ where
 
 impl<I, T> Bits<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     /// Insert a new interval after the BITS has been created. This is very
@@ -321,7 +321,7 @@ where
 pub struct IterFind<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
 {
     inner: &'a Bits<I, T>,
     off: usize,
@@ -332,7 +332,7 @@ where
 impl<'a, I, T> Iterator for IterFind<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
 {
     type Item = &'a Interval<I, T>;
 
@@ -358,7 +358,7 @@ where
 pub struct IterBits<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
 {
     inner: &'a Bits<I, T>,
     pos: usize,
@@ -367,7 +367,7 @@ where
 impl<'a, I, T> Iterator for IterBits<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
 {
     type Item = &'a Interval<I, T>;
 
@@ -384,7 +384,7 @@ where
 impl<I, T> IntoIterator for Bits<I, T>
 where
     T: Eq + Clone + Send + Sync,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
 {
     type Item = Interval<I, T>;
     type IntoIter = ::std::vec::IntoIter<Self::Item>;
@@ -397,7 +397,7 @@ where
 impl<'a, I, T> IntoIterator for &'a Bits<I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
 {
     type Item = &'a Interval<I, T>;
     type IntoIter = std::slice::Iter<'a, Interval<I, T>>;
@@ -410,7 +410,7 @@ where
 impl<'a, I, T> IntoIterator for &'a mut Bits<I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
 {
     type Item = &'a mut Interval<I, T>;
     type IntoIter = std::slice::IterMut<'a, Interval<I, T>>;

--- a/gtars/src/overlap/iitree.rs
+++ b/gtars/src/overlap/iitree.rs
@@ -1,18 +1,18 @@
 ///
 /// WIP
-/// 
+///
 use std::cmp::Ordering::{self};
 
 use num_traits::{PrimInt, Unsigned};
 
-use crate::common::models::Interval;
 use super::Overlapper;
+use crate::common::models::Interval;
 
 /// An internal wrapper that stores the extra `max` field required by the iitree.
 #[derive(Clone)]
 struct Node<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     start: I,
@@ -23,7 +23,7 @@ where
 
 impl<I, T> Ord for Node<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     #[inline]
@@ -33,7 +33,7 @@ where
 }
 impl<I, T> PartialOrd for Node<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     #[inline]
@@ -43,13 +43,13 @@ where
 }
 impl<I, T> Eq for Node<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
 }
 impl<I, T> PartialEq for Node<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     #[inline]
@@ -59,14 +59,14 @@ where
 }
 
 ///
-/// 
+///
 /// The Implicit interval tree, described in: https://academic.oup.com/bioinformatics/article/37/9/1315/5910546
 ///
 pub struct IITree<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     max_level: usize,
-    nodes: Vec<Node<I, T>>
+    nodes: Vec<Node<I, T>>,
 }

--- a/gtars/src/overlap/traits.rs
+++ b/gtars/src/overlap/traits.rs
@@ -5,10 +5,17 @@ pub use crate::common::models::Interval;
 pub trait Overlapper<I, T>: Send + Sync
 where
     I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
-    T: Eq   + Clone    + Send + Sync,
+    T: Eq + Clone + Send + Sync,
 {
-    fn build(intervals: Vec<Interval<I, T>>) -> Self  where Self: Sized;
-    // TODO: how to make this an iterator instead? itearting
-    // over found intervals, i believe, is more performant.
+    fn build(intervals: Vec<Interval<I, T>>) -> Self
+    where
+        Self: Sized;
+
     fn find(&self, start: I, end: I) -> Vec<Interval<I, T>>;
+
+    fn find_iter<'a>(
+        &'a self,
+        start: I,
+        end: I,
+    ) -> Box<dyn Iterator<Item = &'a Interval<I, T>> + 'a>;
 }

--- a/gtars/src/overlap/traits.rs
+++ b/gtars/src/overlap/traits.rs
@@ -4,7 +4,7 @@ pub use crate::common::models::Interval;
 
 pub trait Overlapper<I, T>: Send + Sync
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Unsigned + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     fn build(intervals: Vec<Interval<I, T>>) -> Self

--- a/gtars/src/refget/mod.rs
+++ b/gtars/src/refget/mod.rs
@@ -80,6 +80,7 @@ mod tests {
     use std::time::Instant;
     use store::GlobalRefgetStore;
     use store::StorageMode;
+    use tempfile::tempdir;
     #[test]
     #[ignore]
     fn test_loading_large_fasta_file() {
@@ -144,13 +145,17 @@ mod tests {
 
     #[test]
     fn test_get_sequence_encoded() {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+        let temp_path = temp_dir.path();
         // Create a new sequence store
         let mut store = GlobalRefgetStore::new(StorageMode::Encoded);
         // let fasta_path = "tests/data/subset.fa.gz";
         let fasta_path = "tests/data/fasta/base.fa.gz";
+        let temp_fasta = temp_path.join("base.fa.gz");
+        std::fs::copy(fasta_path, &temp_fasta).expect("Failed to copy base.fa.gz to tempdir");
 
         // Add sequences to the store
-        store.import_fasta(fasta_path).unwrap();
+        store.import_fasta(temp_fasta).unwrap();
         println!("Listing sequences in the store...");
         // let sequences = store.list_sequence_digests();
         // let digest = &sequences[0];

--- a/gtars/src/refget/store.rs
+++ b/gtars/src/refget/store.rs
@@ -737,13 +737,16 @@ mod tests {
         // Create a temporary directory for the test
         let temp_dir = tempdir().unwrap();
         let temp_path = temp_dir.path();
+        let temp_fasta = temp_path.join("base.fa.gz");
+        std::fs::copy("tests/data/fasta/base.fa.gz", &temp_fasta)
+            .expect("Failed to copy base.fa.gz to tempdir");
 
         // Create a new sequence store
         let mut store = GlobalRefgetStore::new(StorageMode::Encoded);
 
         // Import a FASTA file into the store
         // store.import_fasta("tests/data/subset.fa.gz").unwrap();
-        store.import_fasta("tests/data/fasta/base.fa.gz").unwrap();
+        store.import_fasta(&temp_fasta).unwrap();
 
         // Get the sequence keys for verification (assuming we know the test file contains 3 sequences)
         let sequence_keys: Vec<[u8; 32]> = store.sequence_store.keys().cloned().collect();


### PR DESCRIPTION
Please feel free to take or leave any of this!

This adds the `find_iter` method to the `Overlapper` trait. The trick was adding the `Box<dyn>` over the return Iterator.
This also adds an iterator to ailist. 
I also added the constructor stuff I mentioned in a previous PR, reusing the decompose object. Possibly premature optimization, so that could be removed to be benchmarked at a future point.
Note that in order to return a ref iter for ailist I made the `data_list` hold the Intervals themselves. Otherwise there was nothing to return a reference to. 

TODO:

- [x] Add documentation (Ran out of time today)
- [x] Fix name of `data_list` on ailist
- [x] Remove `Default` impl and just derive it for ailist
- [x] Clean up commented out stuff

---

Added two other commits. I'd have made the PRs but Github sucks at stacked PRs from a fork it seems :( 

30d30b91c20d21efb259a064b87c0ec84c6861e8 - the `Overlapper::find_iter` method, improvements to `AiList`, impl for `find_iter` for `bits`
c7350ee7b43426dc9f61509b6363a6c304c612df - fixes bits doc tests
32a033eca442eb4dad101a540518e4442388d915 - fixes a failing test elsewhere by moving the fasta to a tempdir at the start of the tests. 
61035cb82cb834f10cd183ccf49ff6d896de5b59 - removes `Ord` trait bound which is redundant, as pointed out by @donaldcampbelljr 