### PR TITLE
Add ability to retrieve sequences from Store when using a BED file

### DIFF
--- a/bindings/python/py_src/gtars/ailist/__init__.pyi
+++ b/bindings/python/py_src/gtars/ailist/__init__.pyi
@@ -12,19 +12,16 @@ class Interval:
         :param start: The start of the interval.
         :param end: The end of the interval.
         """
-
     @property
     def start(self) -> int:
         """
         The start of the interval.
         """
-
     @property
     def end(self) -> int:
         """
         The end of the interval.
         """
-
     def __repr__(self) -> str: ...
 
 class AIList:
@@ -43,7 +40,6 @@ class AIList:
         :param intervals: A list of intervals.
         :param minimum_coverage_length: The minimum length of the coverage.
         """
-
     def query(self, interval: Interval) -> List[Interval]:
         """
         Query the AIList object for overlapping intervals.

--- a/bindings/python/py_src/gtars/models/__init__.pyi
+++ b/bindings/python/py_src/gtars/models/__init__.pyi
@@ -25,14 +25,12 @@ class RegionSet:
         :param path: path to the bed file
         """
         ...
-    
     @classmethod
     def from_regions(cls, regions: List[Region]) -> "RegionSet":
         """
         :param regions: list of regions
         """
         ...
-
     @property
     def identifier(self) -> str:
         """
@@ -41,7 +39,6 @@ class RegionSet:
         :return: bed digest/identifier
         """
         ...
-
     @property
     def path(self) -> str:
         """
@@ -50,21 +47,18 @@ class RegionSet:
         :return: bed file path
         """
         ...
-
     @property
     def header(self) -> str:
         """
         Header of the bed file
         """
         ...
-
     @property
     def file_digest(self) -> str:
         """
         Digest of whole bed file (with all columns)
         """
         ...
-
     def to_bed(self, path: str) -> None:
         """
         Save RegionSet as bed file
@@ -72,7 +66,6 @@ class RegionSet:
         :param path: path to the bed file that has to be saved
         """
         ...
-
     def to_bed_gz(self, path: str) -> None:
         """
         Save RegionSet as bed.gz file
@@ -80,7 +73,6 @@ class RegionSet:
         :param path: path to the bed file that has to be saved
         """
         ...
-
     def to_bigbed(self, out_path: str, chrom_size: str) -> None:
         """
         Save RegionSet as bigBed file
@@ -89,25 +81,21 @@ class RegionSet:
         :param chrom_size: path to the chrom sizes file
         """
         ...
-
     def sort(self) -> None:
         """
         Sort the regions
         """
         ...
-
     def mean_region_width(self) -> int:
         """
         Mean width of the regions
         """
         ...
-
     def __len__(self) -> int:
         """
         Size of the regionset
         """
         ...
-
     def __iter__(self): ...
     def __getitem__(self, indx: int): ...
     def __repr__(self): ...

--- a/bindings/python/py_src/gtars/refget/__init__.pyi
+++ b/bindings/python/py_src/gtars/refget/__init__.pyi
@@ -6,6 +6,7 @@ class AlphabetType(Enum):
     """
     Represents the type of alphabet for a sequence.
     """
+
     Dna2bit: int
     Dna3bit: int
     DnaIupac: int
@@ -19,6 +20,7 @@ class SequenceMetadata:
     """
     Metadata for a biological sequence.
     """
+
     name: str
     length: int
     sha512t24u: str
@@ -32,8 +34,9 @@ class SequenceRecord:
     """
     A record representing a biological sequence, including its metadata and optional data.
     """
+
     metadata: SequenceMetadata
-    data: Optional[bytes] # Vec<u8> maps to bytes in Python
+    data: Optional[bytes]  # Vec<u8> maps to bytes in Python
 
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
@@ -42,6 +45,7 @@ class SeqColDigestLvl1:
     """
     Level 1 digests for a sequence collection.
     """
+
     sequences_digest: str
     names_digest: str
     lengths_digest: str
@@ -53,6 +57,7 @@ class SequenceCollection:
     """
     A collection of biological sequences.
     """
+
     sequences: List[SequenceRecord]
     digest: str
     lvl1: SeqColDigestLvl1
@@ -62,10 +67,28 @@ class SequenceCollection:
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
 
+class RetrievedSequence:
+    """
+    Represents a retrieved sequence segment with its metadata.
+    Exposed from the Rust `PyRetrievedSequence` struct.
+    """
+
+    sequence: str
+    chrom_name: str
+    start: int
+    end: int
+
+    def __init__(
+        self, sequence: str, chrom_name: str, start: int, end: int
+    ) -> None: ...
+    def __repr__(self) -> str: ...
+    def __str__(self) -> str: ...
+
 class StorageMode(Enum):
     """
     Defines how sequence data is stored in the Refget store.
     """
+
     Raw: int
     Encoded: int
 
@@ -73,6 +96,7 @@ class GlobalRefgetStore:
     """
     A global store for refget sequences, allowing import, retrieval, and storage operations.
     """
+
     def __init__(self, mode: StorageMode) -> None: ...
     def import_fasta(self, file_path: Union[str, PathLike]) -> None:
         """
@@ -84,7 +108,9 @@ class GlobalRefgetStore:
         Retrieves a sequence record by its SHA512t24u or MD5 digest.
         """
         ...
-    def get_sequence_by_collection_and_name(self, collection_digest: str, sequence_name: str) -> Optional[SequenceRecord]:
+    def get_sequence_by_collection_and_name(
+        self, collection_digest: str, sequence_name: str
+    ) -> Optional[SequenceRecord]:
         """
         Retrieve a SequenceRecord from the store by its collection digest and name
         """
@@ -102,21 +128,22 @@ class GlobalRefgetStore:
 
         """
         ...
-
-    def write_store_to_directory(self, root_path: Union[str, PathLike], seqdata_path_template: str) -> None:
+    def write_store_to_directory(
+        self, root_path: Union[str, PathLike], seqdata_path_template: str
+    ) -> None:
         """
         Write a GlobalRefgetStore object to a directory
         """
         ...
-
     @classmethod
-    def load_from_directory(cls: Type["GlobalRefgetStore"], root_path: Union[str, PathLike]) -> "GlobalRefgetStore":
+    def load_from_directory(
+        cls: Type["GlobalRefgetStore"], root_path: Union[str, PathLike]
+    ) -> "GlobalRefgetStore":
         """
         Load a GlobalRefgetStore from a directory path
         """
 
         ...
-
     def __str__(self) -> str: ...
     def __repr__(self) -> str: ...
 

--- a/bindings/python/py_src/gtars/tokenizers/__init__.pyi
+++ b/bindings/python/py_src/gtars/tokenizers/__init__.pyi
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Optional, Union
 
 class Tokenizer:
     def __init__(self, path: str) -> None: ...
-    \
     @classmethod
     def from_config(cls, cfg: str) -> "Tokenizer":
         """
@@ -12,7 +11,6 @@ class Tokenizer:
         Returns:
             Tokenizer: An instance of the Tokenizer class.
         """
-
     @classmethod
     def from_bed(cls, path: str) -> "Tokenizer":
         """
@@ -22,7 +20,6 @@ class Tokenizer:
         Returns:
             Tokenizer: An instance of the Tokenizer class.
         """
-    
     @classmethod
     def from_pretrained(cls, model_name: str) -> "Tokenizer":
         """
@@ -32,8 +29,6 @@ class Tokenizer:
         Returns:
             Tokenizer: An instance of the Tokenizer class.
         """
-
-
     def tokenize(self, regions: Any) -> List[str]:
         """
         Tokenizes the input regions into a list of tokens.
@@ -42,7 +37,6 @@ class Tokenizer:
         Returns:
             List[str]: A list of tokens.
         """
-
     def encode(self, tokens: Any) -> Union[List[int], int]:
         """
         Encodes the input tokens into a list of token IDs.
@@ -51,7 +45,6 @@ class Tokenizer:
         Returns:
             Union[List[int], int]: A list of token IDs or a single token ID.
         """
-
     def decode(self, ids: Any) -> Union[List[str], str]:
         """
         Decodes the input token IDs into a list of tokens.
@@ -60,7 +53,6 @@ class Tokenizer:
         Returns:
             Union[List[str], str]: A list of tokens or a single token.
         """
-
     def convert_ids_to_tokens(self, id: Any) -> Union[List[str], str]:
         """
         Converts the input token IDs into a list of tokens.
@@ -69,7 +61,6 @@ class Tokenizer:
         Returns:
             Union[List[str], str]: A list of tokens or a single token.
         """
-
     def convert_tokens_to_ids(self, region: Any) -> Union[List[int], int]:
         """
         Converts the input tokens into a list of token IDs.
@@ -78,52 +69,36 @@ class Tokenizer:
         Returns:
             Union[List[int], int]: A list of token IDs or a single token ID.
         """
-
     @property
     def unk_token(self) -> str: ...
-
     @property
     def pad_token(self) -> str: ...
-    
     @property
     def mask_token(self) -> str: ...
-    
     @property
     def cls_token(self) -> str: ...
-    
     @property
     def bos_token(self) -> str: ...
-    
     @property
     def eos_token(self) -> str: ...
-    
     @property
     def sep_token(self) -> str: ...
-    
     @property
     def pad_token_id(self) -> int: ...
-    
     @property
     def mask_token_id(self) -> int: ...
-    
     @property
     def cls_token_id(self) -> int: ...
-    
     @property
     def bos_token_id(self) -> int: ...
-    
     @property
     def eos_token_id(self) -> int: ...
-    
     @property
     def sep_token_id(self) -> int: ...
-    
     @property
     def unk_token_id(self) -> int: ...
-    
     @property
     def vocab_size(self) -> int: ...
-    
     @property
     def special_tokens_map(self) -> Dict[str, Optional[str]]:
         """
@@ -131,14 +106,12 @@ class Tokenizer:
         Returns:
             Dict[str, Optional[str]]: A dictionary mapping special tokens to their string representations.
         """
-
     def get_vocab(self) -> Dict[str, int]:
         """
         Returns the vocabulary of the tokenizer.
         Returns:
             Dict[str, int]: A dictionary mapping tokens to their IDs.
         """
-
     def __len__(self) -> int: ...
     def __repr__(self) -> str: ...
     def __call__(self, regions: Any) -> Any: ...
@@ -154,28 +127,24 @@ class Universe:
         Args:
             universe (Any): The underlying Rust Universe object.
         """
-
     def len(self) -> int:
         """
         Returns the number of regions in the Universe.
         Returns:
             int: The number of regions.
         """
-
     def is_empty(self) -> bool:
         """
         Checks if the Universe is empty.
         Returns:
             bool: True if the Universe is empty, False otherwise.
         """
-
     def __len__(self) -> int:
         """
         Returns the number of regions in the Universe.
         Returns:
             int: The number of regions.
         """
-
     def __repr__(self) -> str:
         """
         Returns a string representation of the Universe.

--- a/bindings/python/src/refget/mod.rs
+++ b/bindings/python/src/refget/mod.rs
@@ -80,6 +80,7 @@ pub struct PySequenceMetadata {
 }
 
 #[pyclass(name = "SequenceRecord")]
+#[derive(Clone)]
 pub struct PySequenceRecord {
     #[pyo3(get, set)]
     pub metadata: PySequenceMetadata,
@@ -98,8 +99,8 @@ pub struct PySeqColDigestLvl1 {
     pub lengths_digest: String,
 }
 
-#[pyclass(name = "SequenceCollection")]
 #[derive(Clone)]
+#[pyclass(name = "SequenceCollection")]
 pub struct PySequenceCollection {
     #[pyo3(get, set)]
     pub sequences: Vec<PySequenceRecord>,

--- a/bindings/python/src/refget/mod.rs
+++ b/bindings/python/src/refget/mod.rs
@@ -12,6 +12,7 @@ use gtars::refget::store::StorageMode;
 use gtars::refget::digest::{md5, sha512t24u};
 use gtars::refget::collection::{SequenceCollection, SequenceMetadata, SequenceRecord, SeqColDigestLvl1};
 use gtars::refget::alphabet::AlphabetType;
+use gtars::refget::store::RetrievedSequence; // This is the Rust-native struct
 
 
 #[pyfunction]
@@ -52,9 +53,8 @@ pub fn digest_fasta(fasta: &Bound<'_, PyAny>) -> PyResult<PySequenceCollection> 
     }
 }
 
-#[pyclass]
+#[pyclass(name = "AlphabetType")]
 #[derive(Clone)]
-#[pyo3(name = "AlphabetType")]
 pub enum PyAlphabetType {
     Dna2bit,
     Dna3bit,
@@ -64,9 +64,8 @@ pub enum PyAlphabetType {
     Unknown,
 }
 
-#[pyclass]
+#[pyclass(name = "SequenceMetadata")]
 #[derive(Clone)]
-#[pyo3(name = "SequenceMetadata")]
 pub struct PySequenceMetadata {
     #[pyo3(get, set)]
     pub name: String,
@@ -80,9 +79,7 @@ pub struct PySequenceMetadata {
     pub alphabet: PyAlphabetType,
 }
 
-#[pyclass]
-#[derive(Clone)]
-#[pyo3(name = "SequenceRecord")]
+#[pyclass(name = "SequenceRecord")]
 pub struct PySequenceRecord {
     #[pyo3(get, set)]
     pub metadata: PySequenceMetadata,
@@ -90,9 +87,8 @@ pub struct PySequenceRecord {
     pub data: Option<Vec<u8>>,
 }
 
-#[pyclass]
+#[pyclass(name = "SeqColDigestLvl1")]
 #[derive(Clone)]
-#[pyo3(name = "SeqColDigestLvl1")]
 pub struct PySeqColDigestLvl1 {
     #[pyo3(get, set)]
     pub sequences_digest: String,
@@ -102,9 +98,8 @@ pub struct PySeqColDigestLvl1 {
     pub lengths_digest: String,
 }
 
-#[pyclass]
+#[pyclass(name = "SequenceCollection")]
 #[derive(Clone)]
-#[pyo3(name = "SequenceCollection")]
 pub struct PySequenceCollection {
     #[pyo3(get, set)]
     pub sequences: Vec<PySequenceRecord>,
@@ -117,6 +112,61 @@ pub struct PySequenceCollection {
     #[pyo3(get, set)]
     pub has_data: bool,
 }
+
+
+#[pyclass(name = "RetrievedSequence")]
+#[derive(Debug, Clone, PartialEq)]
+pub struct PyRetrievedSequence {
+    #[pyo3(get, set)]
+    pub sequence: String,
+    #[pyo3(get, set)]
+    pub chrom_name: String,
+    #[pyo3(get, set)]
+    pub start: u32,
+    #[pyo3(get, set)]
+    pub end: u32,
+}
+
+// This `From` implementation converts the Rust-native `RetrievedSequence`
+// into the Python-exposed `PyRetrievedSequence`.
+impl From<gtars::refget::store::RetrievedSequence> for PyRetrievedSequence {
+    fn from(value: gtars::refget::store::RetrievedSequence) -> Self {
+        PyRetrievedSequence {
+            sequence: value.sequence,
+            chrom_name: value.chrom_name,
+            start: value.start,
+            end: value.end,
+        }
+    }
+}
+
+#[pymethods]
+impl PyRetrievedSequence {
+    #[new]
+    fn new(sequence: String, chrom_name: String, start: u32, end: u32) -> Self {
+        PyRetrievedSequence {
+            sequence,
+            chrom_name,
+            start,
+            end,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "RetrievedSequence(chrom_name='{}', start={}, end={}, sequence='{}')",
+            self.chrom_name, self.start, self.end, self.sequence
+        )
+    }
+
+    fn __str__(&self) -> String {
+        format!(
+            "{}|{}-{}: {}",
+            self.chrom_name, self.start, self.end, self.sequence
+        )
+    }
+}
+
 
 #[pymethods]
 impl PyAlphabetType {
@@ -266,9 +316,8 @@ impl From<SequenceCollection> for PySequenceCollection {
     }
 }
 
-#[pyclass]
+#[pyclass(name = "StorageMode")]
 #[derive(Clone)]
-#[pyo3(name = "StorageMode")]
 pub enum PyStorageMode {
     Raw,
     Encoded,
@@ -292,8 +341,7 @@ impl From<PyStorageMode> for StorageMode {
     }
 }
 
-#[pyclass]
-#[pyo3(name = "GlobalRefgetStore")]
+#[pyclass(name = "GlobalRefgetStore")]
 pub struct PyGlobalRefgetStore {
     inner: GlobalRefgetStore,
 }
@@ -317,7 +365,7 @@ impl PyGlobalRefgetStore {
         // Try as SHA512t24u first (32 bytes)
         let result = self.inner.get_sequence_by_id(digest.as_bytes())
             .map(|record| PySequenceRecord::from(record.clone()));
-        
+
         // If not found and input looks like MD5 (32 hex chars), try MD5 lookup
         if result.is_none() && digest.len() == 32 {
             return Ok(self.inner.get_sequence_by_md5(digest.as_bytes())
@@ -348,6 +396,32 @@ impl PyGlobalRefgetStore {
         Ok(Self { inner: store })
     }
 
+    fn get_seqs_bed_file(
+        &self,
+        collection_digest: &str,
+        bed_file_path: &str,
+        output_file_path: &str,
+    ) -> PyResult<()> {
+        // Rust function expects K: AsRef<[u8]>, &str works directly
+        self.inner.get_seqs_bed_file(collection_digest, bed_file_path, output_file_path)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("Error retrieving sequences and writing to file: {}", e)))
+    }
+
+    fn get_seqs_bed_file_to_vec(
+        &self,
+        collection_digest: &str,
+        bed_file_path: &str,
+    ) -> PyResult<Vec<PyRetrievedSequence>> {
+        // Corrected: use `let ... = ...?;` to bind the result
+        let rust_results = self.inner.get_seqs_bed_file_to_vec(collection_digest, bed_file_path)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("Error retrieving sequences to list: {}", e)))?;
+
+        // Now `rust_results` is available
+        let py_results: Vec<PyRetrievedSequence> = rust_results.into_iter().map(PyRetrievedSequence::from).collect();
+
+        Ok(py_results)
+    }
+
     fn __str__(&self) -> String {
         format!("{}", self.inner)
     }
@@ -370,5 +444,6 @@ pub fn refget(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySequenceCollection>()?;
     m.add_class::<PyStorageMode>()?;
     m.add_class::<PyGlobalRefgetStore>()?;
+    m.add_class::<PyRetrievedSequence>()?;
     Ok(())
 }

--- a/bindings/python/tests/test_refget.py
+++ b/bindings/python/tests/test_refget.py
@@ -4,83 +4,84 @@ from gtars.refget import (
     StorageMode,
     digest_fasta,
     sha512t24u_digest,
-    md5_digest
+    md5_digest,
+    RetrievedSequence,
 )
 
 import os
 import tempfile
 
+
 class TestRefget:
-    
     def test_digest_fasta_basic(self):
         """Test basic functionality of digest_fasta"""
         fasta_path = "../../gtars/tests/data/fasta/base.fa"
-        
+
         # Test that digest_fasta returns a PySequenceCollection
         result = digest_fasta(fasta_path)
-        
+
         # Test that it has the expected structure
-        assert hasattr(result, 'sequences')
-        assert hasattr(result, 'digest')
-        assert hasattr(result, 'lvl1')
-        assert hasattr(result, 'file_path')
-        assert hasattr(result, 'has_data')
-        
+        assert hasattr(result, "sequences")
+        assert hasattr(result, "digest")
+        assert hasattr(result, "lvl1")
+        assert hasattr(result, "file_path")
+        assert hasattr(result, "has_data")
+
         # Test that sequences is a list
         assert isinstance(result.sequences, list)
-        
+
         # Test that we have the expected number of sequences (from the Rust test)
         assert len(result.sequences) == 3
-        
+
         # Test the first sequence
         seq0 = result.sequences[0]
-        assert hasattr(seq0, 'metadata')
-        assert hasattr(seq0, 'data')
-        
+        assert hasattr(seq0, "metadata")
+        assert hasattr(seq0, "data")
+
         # Test metadata
         metadata = seq0.metadata
-        assert hasattr(metadata, 'name')
-        assert hasattr(metadata, 'length')
-        assert hasattr(metadata, 'sha512t24u')
-        assert hasattr(metadata, 'md5')
-        assert hasattr(metadata, 'alphabet')
-        
+        assert hasattr(metadata, "name")
+        assert hasattr(metadata, "length")
+        assert hasattr(metadata, "sha512t24u")
+        assert hasattr(metadata, "md5")
+        assert hasattr(metadata, "alphabet")
+
         # Test specific values from the Rust test
         assert metadata.length == 8
         assert metadata.sha512t24u == "iYtREV555dUFKg2_agSJW6suquUyPpMw"
         assert metadata.md5 == "5f63cfaa3ef61f88c9635fb9d18ec945"
-        
+
         # Test lvl1 digests
         lvl1 = result.lvl1
-        assert hasattr(lvl1, 'sequences_digest')
-        assert hasattr(lvl1, 'names_digest')
-        assert hasattr(lvl1, 'lengths_digest')
-        
+        assert hasattr(lvl1, "sequences_digest")
+        assert hasattr(lvl1, "names_digest")
+        assert hasattr(lvl1, "lengths_digest")
+
         # Test specific digest values from the Rust test
         assert lvl1.sequences_digest == "0uDQVLuHaOZi1u76LjV__yrVUIz9Bwhr"
         assert lvl1.names_digest == "Fw1r9eRxfOZD98KKrhlYQNEdSRHoVxAG"
         assert lvl1.lengths_digest == "cGRMZIb3AVgkcAfNv39RN7hnT5Chk7RX"
-        
+
         # Test string representations
         assert str(result).startswith("SequenceCollection with 3 sequences")
         assert str(metadata).startswith("SequenceMetadata for sequence")
         assert str(lvl1).startswith("SeqColDigestLvl1:")
-        
+
     def test_digest_fasta_nonexistent_file(self):
         """Test that digest_fasta raises an error for non-existent files"""
         with pytest.raises(Exception):
             digest_fasta("nonexistent.fa")
 
     def test_global_refget_store_basic(self):
-            """Test basic creation and operations of GlobalRefgetStore"""
-            # Test store creation with both modes
-            store_raw = GlobalRefgetStore(StorageMode.Raw)
-            store_encoded = GlobalRefgetStore(StorageMode.Encoded)
+        """Test basic creation and operations of GlobalRefgetStore"""
+        # Test store creation with both modes
+        store_raw = GlobalRefgetStore(StorageMode.Raw)
+        store_encoded = GlobalRefgetStore(StorageMode.Encoded)
 
-            # Test string representations
-            #print(store_raw.__repr__)
-            assert repr(store_raw).startswith("<GlobalRefgetStore")
-            assert repr(store_encoded).startswith("<GlobalRefgetStore")
+        # Test string representations
+        # print(store_raw.__repr__)
+        assert repr(store_raw).startswith("<GlobalRefgetStore")
+        assert repr(store_encoded).startswith("<GlobalRefgetStore")
 
     def test_store_import_and_retrieve(self):
         """Test importing FASTA and retrieving sequences"""
@@ -112,7 +113,7 @@ class TestRefget:
         substr = store.get_substring(sha512, 0, 4)
         assert substr is not None
         assert len(substr) == 4
-#
+
     def test_store_persistence(self):
         """Test saving and loading store"""
         store = GlobalRefgetStore(StorageMode.Raw)
@@ -135,7 +136,7 @@ class TestRefget:
             assert seq2 is not None
             assert seq1.metadata.length == seq2.metadata.length
             assert seq1.metadata.sha512t24u == seq2.metadata.sha512t24u
-#
+
     def test_store_errors(self):
         """Test error conditions"""
         store = GlobalRefgetStore(StorageMode.Raw)
@@ -153,7 +154,7 @@ class TestRefget:
         store.import_fasta("../../gtars/tests/data/fasta/base.fa")
         assert store.get_substring(sha512, 10, 5) is None  # end < start
         assert store.get_substring(sha512, 0, 100) is None  # end > length
-#
+
     def test_store_collection_operations(self):
         """Test collection-related operations"""
         store = GlobalRefgetStore(StorageMode.Raw)
@@ -165,10 +166,87 @@ class TestRefget:
         # Get sequence from default collection
         result = digest_fasta(fasta_path)
         seq = store.get_sequence_by_collection_and_name(
-            result.digest,
-            result.sequences[0].metadata.name
+            result.digest, result.sequences[0].metadata.name
         )
 
         assert seq is not None
         assert seq.metadata.length == 8
         assert seq.metadata.sha512t24u == "iYtREV555dUFKg2_agSJW6suquUyPpMw"
+
+    def test_get_seqs_from_bed_file_bindings(self):
+        """
+        Test both get_seqs_bed_file (writes to file)
+        and get_seqs_bed_file_to_vec (returns list) bindings.
+        """
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = temp_dir_str
+
+            fasta_content = ">chr1\n" "ATGCATGCATGC\n" ">chr2\n" "GGGGAAAA\n"
+            temp_fasta_path = os.path.join(temp_dir, "test.fa")
+            with open(temp_fasta_path, "w") as f:
+                f.write(fasta_content)
+
+
+            store = GlobalRefgetStore(StorageMode.Encoded)
+            imported_collection = store.import_fasta(temp_fasta_path)
+            result = digest_fasta(temp_fasta_path)
+
+            collection_digest = result.digest
+
+
+            chr1_sha = sha512t24u_digest(b"ATGCATGCATGC")
+            chr1_md5 = md5_digest(b"ATGCATGCATGC")
+            chr2_sha = sha512t24u_digest(b"GGGGAAAA")
+            chr2_md5 = md5_digest(b"GGGGAAAA")
+
+            bed_content = (
+                "chr1\t0\t5\n"
+                "chr1\t8\t12\n"
+                "chr2\t0\t4\n"
+                "chr_nonexistent\t10\t20\n"
+                "chr1\t-5\t100"
+            )
+            temp_bed_path = os.path.join(temp_dir, "test.bed")
+            with open(temp_bed_path, "w") as f:
+                f.write(bed_content)
+
+            temp_output_fa_path = os.path.join(temp_dir, "output.fa")
+            store.get_seqs_bed_file(
+                collection_digest, temp_bed_path, temp_output_fa_path
+            )
+
+            with open(temp_output_fa_path, "r") as f:
+                output_fa_content = f.read()
+
+            expected_fa_content = f""">chr1 12 dna2bit {chr1_sha} {chr1_md5}
+ATGCAATGC
+>chr2 8 dna2bit {chr2_sha} {chr2_md5}
+GGGG
+"""
+
+            assert (
+                output_fa_content.strip() == expected_fa_content.strip()
+            ), "Output FASTA file content mismatch"
+            print("✓ get_seqs_bed_file binding test passed.")
+
+            vec_result = store.get_seqs_bed_file_to_vec(
+                collection_digest, temp_bed_path
+            )
+
+            expected_vec = [
+                RetrievedSequence(sequence="ATGCA", chrom_name="chr1", start=0, end=5),
+                RetrievedSequence(sequence="ATGC", chrom_name="chr1", start=8, end=12),
+                RetrievedSequence(sequence="GGGG", chrom_name="chr2", start=0, end=4),
+            ]
+
+            assert len(vec_result) == len(
+                expected_vec
+            ), "Length of retrieved sequence list mismatch"
+            for i in range(len(vec_result)):
+                assert vec_result[i].sequence == expected_vec[i].sequence
+                assert vec_result[i].chrom_name == expected_vec[i].chrom_name
+                assert vec_result[i].start == expected_vec[i].start
+                assert vec_result[i].end == expected_vec[i].end
+
+            print("✓ get_seqs_bed_file_to_vec binding test passed.")

--- a/bindings/python/tests/test_regionset.py
+++ b/bindings/python/tests/test_regionset.py
@@ -5,8 +5,8 @@ import pytest
 
 from gtars.models import RegionSet
 
-class TestRegionSet:
 
+class TestRegionSet:
     @pytest.mark.parametrize(
         "bed_file",
         [
@@ -14,11 +14,9 @@ class TestRegionSet:
         ],
     )
     def test_mean_region_width(self, bed_file):
-
         rs = RegionSet(bed_file)
 
         assert rs.mean_region_width() == 4.22
-
 
     @pytest
     def test_from_regions(self):
@@ -29,8 +27,6 @@ class TestRegionSet:
             Region(chrom="chr19", start=19, end=810),
         ]
         rs = RegionSet.from_regions(regions)
-        
+
         assert isinstance(rs, RegionSet)
         assert len(rs) == 2
-
-        

--- a/bindings/python/tests/test_tokenizers.py
+++ b/bindings/python/tests/test_tokenizers.py
@@ -153,20 +153,6 @@ def test_tokenize_with_multi_overlap():
     assert tokenizer.convert_tokens_to_ids(tokenized[1]) == 8
 
 
-def test_tokenize_with_order():
-    cfg_path = os.path.join(TEST_DATA_DIR, "tokenizers", "peaks.scored.bed")
-    tokenizer = Tokenizer(cfg_path)
-    regions = [Region("chr9", 3526178, 3526249), Region("chr9", 3526051, 3526145)]
-    tokenized = tokenizer.tokenize(regions)
-    assert tokenized is not None
-    assert len(tokenized) == 2
-    assert tokenized[0] == "chr9:3526071-3526165"
-    assert tokenizer.convert_tokens_to_ids(tokenized[0]) == 11
-
-    assert tokenized[1] == "chr9:3526183-3526269"
-    assert tokenizer.convert_tokens_to_ids(tokenized[1]) == 10
-
-
 def test_get_vocab():
     cfg_path = os.path.join(TEST_DATA_DIR, "tokenizers", "peaks.scored.bed")
     tokenizer = Tokenizer(cfg_path)
@@ -212,23 +198,22 @@ def test_decode_tokens():
     assert isinstance(decoded, list)
     assert decoded == ["chr9:3526071-3526165"]
 
+# @pytest.mark.skip(reason="Needs to be fixed")
+# def test_special_tokens_mask():
+#     cfg_path = os.path.join(TEST_DATA_DIR, "tokenizers", "peaks.scored.bed")
+#     tokenizer = Tokenizer(cfg_path)
 
-@pytest.mark.skip(reason="Needs to be fixed")
-def test_special_tokens_mask():
-    cfg_path = os.path.join(TEST_DATA_DIR, "tokenizers", "peaks.scored.bed")
-    tokenizer = Tokenizer(cfg_path)
+#     tokens = ["<pad>", "chr9:3526071-3526165", "<unk>"]
+#     special_tokens_mask = tokenizer.get_special_tokens_mask(tokens)
 
-    tokens = ["<pad>", "chr9:3526071-3526165", "<unk>"]
-    special_tokens_mask = tokenizer.get_special_tokens_mask(tokens)
-
-    assert special_tokens_mask is not None
-    assert isinstance(special_tokens_mask, list)
-    assert len(special_tokens_mask) == 3
-    assert special_tokens_mask == [
-        1,
-        0,
-        1,
-    ]  # Assuming <pad> and <unk> are special tokens
+#     assert special_tokens_mask is not None
+#     assert isinstance(special_tokens_mask, list)
+#     assert len(special_tokens_mask) == 3
+#     assert special_tokens_mask == [
+#         1,
+#         0,
+#         1,
+#     ]  # Assuming <pad> and <unk> are special tokens
 
 
 def test_tokenizer_call_magic_method():

--- a/gtars/src/refget/store.rs
+++ b/gtars/src/refget/store.rs
@@ -250,6 +250,22 @@ impl GlobalRefgetStore {
         None
     }
 
+
+    /// Given a Sequence Collection digest and a bed file path
+    /// retrieve sequences and write to a file
+    pub fn get_seqs_bed_file<K: AsRef<[u8]>>(        &self,
+                                                     collection_digest: K,
+                                                     bed_file_path: &str,
+                                                     output_file_path: &str){
+
+        // Read each line of bed file
+        // for each line in befd file retrieve sequences
+        // write them to fasta file
+
+
+
+    }
+
     /// Retrieve a SequenceRecord from the store by its MD5 digest
     pub fn get_sequence_by_md5<K: AsRef<[u8]>>(&self, seq_md5: K) -> Option<&SequenceRecord> {
         // Look up the SHA512t24u digest using the MD5 lookup
@@ -301,6 +317,8 @@ impl GlobalRefgetStore {
             }
         }
     }
+
+
 
     /// Helper function to get the relative path for a sequence based on its SHA512t24u digest string
     fn get_sequence_path(digest_str: &str, template: &str) -> PathBuf {
@@ -618,6 +636,31 @@ mod tests {
         }
     }
 
+
+    #[test]
+    fn test_refget_store_retrieve_seq(){
+
+        println!("All tests passing.");
+
+        let query_bed_str ="/home/drc/Downloads/test_adding_fastas/INPUT_FILE/testbed.bed";
+        let mut store = GlobalRefgetStore::new(StorageMode::Encoded);
+        store.import_fasta("/home/drc/Downloads/test_adding_fastas/INPUT_FILE/100linesGRCH38.fa").unwrap();
+
+        let known_seq_col_digest = "VRAhrMWmnghggvNFd4qNoRg-J3AqugDh";
+        let know_name = "1";
+
+        let result = store.get_sequence_by_collection_and_name(known_seq_col_digest, know_name).unwrap();
+
+        let seq_digest = result.metadata.sha512t24u.clone();
+        println!("{}", seq_digest);
+
+        let retrieved_substring = store.get_substring(seq_digest, 100, 105).unwrap();
+
+        println!("{}", retrieved_substring);
+        println!("ok");
+
+    }
+
     #[test]
     fn test_global_refget_store() {
         let sequence = b"ACGT";
@@ -834,6 +877,7 @@ mod tests {
                     substring.is_some(),
                     "Should be able to retrieve substring from loaded sequence"
                 );
+                println!("Do we ever get here?");
             }
         }
 

--- a/gtars/src/refget/store.rs
+++ b/gtars/src/refget/store.rs
@@ -83,6 +83,104 @@ struct StoreMetadata {
     created_at: String,
 }
 
+pub struct GetSeqsBedFileIter<'a, K> 
+where K: AsRef<[u8]>
+{
+    store: &'a GlobalRefgetStore,
+    reader: BufReader<Box<dyn Read>>,
+    collection_digest: K,
+    previous_parsed_chr: String,
+    current_seq_digest: String,
+    line_num: usize
+}
+
+impl<K> Iterator for GetSeqsBedFileIter<'_, K> 
+where K: AsRef<[u8]>
+{
+    type Item = Result<RetrievedSequence, Box<dyn std::error::Error>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+
+        let mut line_string = String::new();
+
+        let num_bytes = self.reader.read_line(&mut line_string);
+        match num_bytes {
+            Ok(bytes) => {
+                if bytes == 0 {
+                    return None
+                }
+            },
+            Err(err) => return Some(Err(err.into())) 
+        };
+
+        self.line_num += 1;
+
+        let (parsed_chr, parsed_start, parsed_end) =
+            match parse_bedlike_file(line_string.trim()) {
+                Some(coords) => coords,
+                None => {
+                    let err_str = format!(
+                        "Error reading line {} because it could not be parsed as a BED-like entry: '{}'",
+                        self.line_num + 1,
+                        line_string
+                    );
+                    return Some(Err(err_str.into()))
+                }
+            };
+
+
+        if parsed_start == -1 || parsed_end == -1 {
+            let err_str = format!(
+                "Error reading line {} due to invalid start or end coordinates: '{}'",
+                self.line_num + 1,
+                line_string
+            );
+            return Some(Err(err_str.into()))
+        }
+
+
+        if self.previous_parsed_chr != parsed_chr {
+
+            self.previous_parsed_chr = parsed_chr.clone();
+
+            let result = match self.store.get_sequence_by_collection_and_name(&self.collection_digest, &*parsed_chr) {
+                Some(seq_record) => seq_record,
+                None => {
+                    let err_str = format!(
+                        "Warning: Skipping line {} because sequence '{}' not found in collection '{}'.",
+                        self.line_num + 1,
+                        parsed_chr,
+                        String::from_utf8_lossy(self.collection_digest.as_ref())
+                    );
+                    return Some(Err(err_str.into()))
+                }
+            };
+
+            self.current_seq_digest = result.metadata.sha512t24u.clone();
+
+        }
+
+        let retrieved_substring = match self.store.get_substring(&self.current_seq_digest, parsed_start as usize, parsed_end as usize) {
+            Some(substring) => substring,
+            None => {
+                let err_str = format!(
+                    "Warning: Skipping line {} because substring for digest '{}' from {} to {} not found or invalid.",
+                    self.line_num + 1,
+                    self.current_seq_digest, parsed_start, parsed_end
+                );
+                return Some(Err(err_str.into()))
+            }
+        };
+
+        Some(Ok(RetrievedSequence {
+            sequence: retrieved_substring,
+            chrom_name: parsed_chr,
+            start: parsed_start as u32, // Convert i32 to u32
+            end: parsed_end as u32,     // Convert i32 to u32
+        }))
+    }
+}
+
 impl GlobalRefgetStore {
     /// Generic constructor. Creates a new, empty `GlobalRefgetStore`.
     pub fn new(mode: StorageMode) -> Self {
@@ -262,6 +360,32 @@ impl GlobalRefgetStore {
         None
     }
 
+    pub fn get_seqs_in_bed_file_iter<'a, K: AsRef<[u8]>>(
+        &'a self,
+        collection_digest: K,
+        bed_file_path: &str
+    ) -> Result<GetSeqsBedFileIter<'a, K>, Box<dyn std::error::Error>> {
+        let path = Path::new(bed_file_path);
+        let file_info = get_file_info(&path.to_path_buf());
+        let is_gzipped = file_info.is_gzipped;
+
+        let opened_bed_file = File::open(path)?;
+
+        let reader: Box<dyn Read> = match is_gzipped {
+            true => Box::new(GzDecoder::new(BufReader::new(opened_bed_file))),
+            false => Box::new(opened_bed_file),
+        };
+        let reader = BufReader::new(reader);
+
+        Ok(GetSeqsBedFileIter { 
+            store: self,
+            reader,
+            collection_digest,
+            previous_parsed_chr: String::new(),
+            current_seq_digest: String::new(),
+            line_num: 0
+        })
+    }
 
     /// Given a Sequence Collection digest and a bed file path
     /// retrieve sequences and write to a file
@@ -284,103 +408,37 @@ impl GlobalRefgetStore {
             .append(true)
             .open(output_file_path)?;
 
-        // Read in Bed file and get the sequences, writing to output file along the way
-        let path = Path::new(bed_file_path);
-        let file_info = get_file_info(&path.to_path_buf());
-        let is_gzipped = file_info.is_gzipped;
+        let seq_iter = self.get_seqs_in_bed_file_iter(&collection_digest, bed_file_path)?;
 
-        let opened_bed_file = File::open(path)?;
-
-        let reader: Box<dyn Read> = match is_gzipped {
-            true => Box::new(GzDecoder::new(BufReader::new(opened_bed_file))),
-            false => Box::new(opened_bed_file),
-        };
-        let reader = BufReader::new(reader);
-
-        let mut previous_parsed_chr: String = String::new();
-        let mut current_seq_digest: String = String::new();
+        let mut previous_parsed_chr = String::new();
         let mut current_header: String = String::new();
         let mut previous_header: String = String::new();
 
-        for (line_num, line_result) in reader.lines().enumerate() {
-            let line_string = match line_result {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!(
-                        "Warning: Skipping line {} due to I/O error while reading: {}",
-                        line_num + 1,
-                        e
-                    );
-                    continue;
-                }
-            };
+        for rs in seq_iter.into_iter() {
 
-            // Try to parse the BED-like line
-            let (parsed_chr, parsed_start, parsed_end) =
-                match parse_bedlike_file(&line_string) {
-                    Some(coords) => coords,
-                    None => {
-                        eprintln!(
-                            "Warning: Skipping line {} because it could not be parsed as a BED-like entry: '{}'",
-                            line_num + 1,
-                            line_string
-                        );
-                        continue;
-                    }
-                };
-
-            // Handle the -1 return for parsing errors in parse_bedlike_file
-
-            if parsed_start == -1 || parsed_end == -1 {
-                eprintln!(
-                    "Warning: Skipping line {} due to invalid start or end coordinates: '{}'",
-                    line_num + 1,
-                    line_string
-                );
-                continue;
+            if let Err(err) = rs {
+                eprintln!("{err}");
+                continue
             }
+            let rs = rs.unwrap();
 
+            if previous_parsed_chr != rs.chrom_name {
+                previous_parsed_chr = rs.chrom_name.clone();
 
-            if previous_parsed_chr != parsed_chr {
-                previous_parsed_chr = parsed_chr.clone();
-
-                let result = match self.get_sequence_by_collection_and_name(&collection_digest, &*parsed_chr) {
-                    Some(seq_record) => seq_record,
-                    None => {
-                        eprintln!(
-                            "Warning: Skipping line {} because sequence '{}' not found in collection '{}'.",
-                            line_num + 1,
-                            parsed_chr,
-                            String::from_utf8_lossy(collection_digest.as_ref())
-                        );
-                        continue;
-                    }
-                };
-
-                current_seq_digest = result.metadata.sha512t24u.clone();
+                // If we get this far, the metadata **must** exist, so we will unwrap the present
+                let seq_info = self.get_sequence_by_collection_and_name(&collection_digest, &rs.chrom_name).unwrap();
                 current_header = format!(
                     ">{} {} {} {} {}",
-                    result.metadata.name,
-                    result.metadata.length,
-                    result.metadata.alphabet,
-                    result.metadata.sha512t24u,
-                    result.metadata.md5
+                    seq_info.metadata.name,
+                    seq_info.metadata.length,
+                    seq_info.metadata.alphabet,
+                    seq_info.metadata.sha512t24u,
+                    seq_info.metadata.md5
                 );
             }
 
+            let retrieved_substring = rs.sequence;
 
-
-            let retrieved_substring = match self.get_substring(&current_seq_digest, parsed_start as usize, parsed_end as usize) {
-                Some(substring) => substring,
-                None => {
-                    eprintln!(
-                        "Warning: Skipping line {} because substring for digest '{}' from {} to {} not found or invalid.",
-                        line_num + 1,
-                        current_seq_digest, parsed_start, parsed_end
-                    );
-                    continue;
-                }
-            };
             if previous_header != current_header {
                 let prefix = if previous_header.is_empty() { "" } else { "\n" };
 
@@ -406,105 +464,21 @@ impl GlobalRefgetStore {
         bed_file_path: &str,
     ) -> Result<Vec<RetrievedSequence>, Box<dyn std::error::Error>> {
 
-        let mut retrieved_sequences: Vec<RetrievedSequence> = Vec::new();
 
+        let seq_iter = self.get_seqs_in_bed_file_iter(collection_digest, bed_file_path)?;
 
-        let path = Path::new(bed_file_path);
-        let file_info = get_file_info(&path.to_path_buf());
-        let is_gzipped = file_info.is_gzipped;
-
-        let opened_bed_file = File::open(path)?;
-
-        let reader: Box<dyn Read> = match is_gzipped {
-            true => Box::new(GzDecoder::new(BufReader::new(opened_bed_file))),
-            false => Box::new(opened_bed_file),
-        };
-        let reader = BufReader::new(reader);
-
-        let mut previous_parsed_chr: String = String::new();
-        let mut current_seq_digest: String = String::new();
-
-        for (line_num, line_result) in reader.lines().enumerate() {
-
-            let line_string = match line_result {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!(
-                        "Warning: Skipping line {} due to I/O error while reading: {}",
-                        line_num + 1,
-                        e
-                    );
-                    continue;
+        let retrieved_sequences = seq_iter
+            .into_iter()
+            .filter_map(|rs| {
+                match rs {
+                    Ok(rs) => Some(rs),
+                    Err(err) => {
+                        eprintln!("{err}");
+                        None
+                    },
                 }
-            };
-
-
-            let (parsed_chr, parsed_start, parsed_end) =
-                match parse_bedlike_file(&line_string) {
-                    Some(coords) => coords,
-                    None => {
-                        eprintln!(
-                            "Warning: Skipping line {} because it could not be parsed as a BED-like entry: '{}'",
-                            line_num + 1,
-                            line_string
-                        );
-                        continue;
-                    }
-                };
-
-
-            if parsed_start == -1 || parsed_end == -1 {
-                eprintln!(
-                    "Warning: Skipping line {} due to invalid start or end coordinates: '{}'",
-                    line_num + 1,
-                    line_string
-                );
-                continue;
-            }
-
-
-            if previous_parsed_chr != parsed_chr {
-                previous_parsed_chr = parsed_chr.clone();
-
-
-                let result = match self.get_sequence_by_collection_and_name(&collection_digest, &*parsed_chr) {
-                    Some(seq_record) => seq_record,
-                    None => {
-                        eprintln!(
-                            "Warning: Skipping line {} because sequence '{}' not found in collection '{}'.",
-                            line_num + 1,
-                            parsed_chr,
-                            String::from_utf8_lossy(collection_digest.as_ref())
-                        );
-                        continue;
-                    }
-                };
-
-                current_seq_digest = result.metadata.sha512t24u.clone();
-
-            }
-
-
-            let retrieved_substring = match self.get_substring(&current_seq_digest, parsed_start as usize, parsed_end as usize) {
-                Some(substring) => substring,
-                None => {
-                    eprintln!(
-                        "Warning: Skipping line {} because substring for digest '{}' from {} to {} not found or invalid.",
-                        line_num + 1,
-                        current_seq_digest, parsed_start, parsed_end
-                    );
-                    continue;
-                }
-            };
-
-
-            retrieved_sequences.push(RetrievedSequence {
-                sequence: retrieved_substring,
-                chrom_name: parsed_chr,
-                start: parsed_start as u32, // Convert i32 to u32
-                end: parsed_end as u32,     // Convert i32 to u32
-            });
-        }
+            })
+            .collect::<Vec<RetrievedSequence>>();
 
         Ok(retrieved_sequences)
     }


### PR DESCRIPTION
User can now retrieve sequences from a GlobalRefgetStore when providing a BED file and a sequence collection digest.
- get_seqs_bed_file -> returns retrieved sequences as a fasta file
- get_seqs_bed_file_to_vec -> Vec<RetrievedSequence>