### PR TITLE
When counting score column, set score to 1 if its 0

### DIFF
--- a/gtars/src/uniwig/reading.rs
+++ b/gtars/src/uniwig/reading.rs
@@ -208,11 +208,14 @@ pub fn parse_bedlike_file_with_scores(line: &str) -> Option<(String, i32, i32, i
 
     let _ = fields.next();
 
-    let narrow_peak_score = fields
+    let mut narrow_peak_score = fields
         .next()
         .and_then(|s| s.parse::<i32>().ok())
         .unwrap_or(-1);
 
+    if narrow_peak_score == 0 {
+        narrow_peak_score = 1; // Must do this otherwise regions will be completely ignored during counting
+    }
     // Original code had a remainder of the line, r, but it does not appear to have been used
     // in any way
 


### PR DESCRIPTION
Potential change to counting score column. If the column is 0, it will not be counted at all.
This _may_ be undesirable.

This change can greatly change the F10 score depending on method for creating universe:
<img width="1003" height="1373" alt="image" src="https://github.com/user-attachments/assets/80c01e01-1276-4c85-9e7c-b568cbb9e336" />

`_scored` -> leave score as 0 and essentially ignore/do not count those regios
`_new_score` -> change score to 1 if it is 0, so those regions are counting similarly to the current, no-score method
`_no_score` -> traditional uniwig counting method, every region is counted as a 1.