### PR TITLE
Add lowercase casting for serde

### DIFF
--- a/gtars/src/scatrs/models.rs
+++ b/gtars/src/scatrs/models.rs
@@ -327,6 +327,7 @@ pub struct ScatrsConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
+#[serde(rename_all = "lowercase")] 
 pub enum FragmentDistribution {
     Uniform { 
         count: u32 


### PR DESCRIPTION
When I tried to run the `stage` command at first, I got an error saying the auto-generated config was set to `gaussian` (all lowercase) but the program expected `Gaussian` or `Uniform` (capitalized).

This can be avoided using the `rename_all` directive from `serde`