### PR TITLE
Fix genomicdist bugs

### DIFF
--- a/gtars-genomicdist/src/interval_ranges.rs
+++ b/gtars-genomicdist/src/interval_ranges.rs
@@ -696,6 +696,13 @@ impl IntervalRanges for RegionSet {
             v.sort_by_key(|(_, r)| r.start);
         }
 
+        // Precompute max region width per chromosome for left-side early termination
+        let mut max_width_by_chr: HashMap<String, u32> = HashMap::new();
+        for (chr, candidates) in &other_by_chr {
+            let max_w = candidates.iter().map(|(_, r)| r.end - r.start).max().unwrap_or(0);
+            max_width_by_chr.insert(chr.clone(), max_w);
+        }
+
         let mut result: Vec<(usize, usize, i64)> = Vec::new();
 
         for (self_idx, a) in self.regions.iter().enumerate() {
@@ -708,28 +715,54 @@ impl IntervalRanges for RegionSet {
                 .binary_search_by_key(&a.start, |(_, r)| r.start)
                 .unwrap_or_else(|x| x);
 
+            let gap_dist = |a_reg: &Region, b_reg: &Region| -> i64 {
+                if a_reg.start < b_reg.end && b_reg.start < a_reg.end {
+                    0i64
+                } else if b_reg.end <= a_reg.start {
+                    (a_reg.start as i64) - (b_reg.end as i64)
+                } else {
+                    (b_reg.start as i64) - (a_reg.end as i64)
+                }
+            };
+
+            let max_width = *max_width_by_chr.get(&a.chr).unwrap_or(&0) as i64;
+
             let mut best_other_idx = 0usize;
             let mut best_dist = i64::MAX;
 
-            // Check candidates around the insertion point
-            let check_range_start = if ins >= 2 { ins - 2 } else { 0 };
-            let check_range_end = (ins + 2).min(candidates.len());
+            let mut left_done = ins == 0;
+            let mut right_done = ins >= candidates.len();
+            let mut li = if ins > 0 { ins - 1 } else { 0 };
+            let mut ri = ins;
 
-            for &(other_idx, b) in &candidates[check_range_start..check_range_end] {
-                let dist = if a.start < b.end && b.start < a.end {
-                    // Overlapping
-                    0i64
-                } else if b.end <= a.start {
-                    // b is upstream
-                    (a.start as i64) - (b.end as i64)
-                } else {
-                    // b is downstream
-                    (b.start as i64) - (a.end as i64)
-                };
+            while !left_done || !right_done {
+                if !right_done {
+                    let (other_idx, b) = candidates[ri];
+                    let dist = gap_dist(a, b);
+                    if dist.abs() < best_dist.abs() {
+                        best_dist = dist;
+                        best_other_idx = other_idx;
+                    }
+                    if best_dist == 0 { break; }
+                    ri += 1;
+                    if ri >= candidates.len() || (b.start as i64 - a.end as i64 > best_dist.abs()) {
+                        right_done = true;
+                    }
+                }
 
-                if dist.abs() < best_dist.abs() {
-                    best_dist = dist;
-                    best_other_idx = other_idx;
+                if !left_done {
+                    let (other_idx, b) = candidates[li];
+                    let dist = gap_dist(a, b);
+                    if dist.abs() < best_dist.abs() {
+                        best_dist = dist;
+                        best_other_idx = other_idx;
+                    }
+                    if best_dist == 0 { break; }
+                    if li == 0 || (a.start as i64 - b.start as i64 > best_dist.abs() + max_width) {
+                        left_done = true;
+                    } else {
+                        li -= 1;
+                    }
                 }
             }
 
@@ -1938,6 +1971,78 @@ mod tests {
         let b = make_regionset(vec![("chr1", 100, 200)]);
         let result = a.closest(&b);
         assert_eq!(result.len(), 0);
+    }
+
+    #[rstest]
+    fn test_closest_nearest_far_left_of_insertion() {
+        let a = make_regionset(vec![("chr1", 1000, 1010)]);
+        let b = make_regionset(vec![
+            ("chr1", 0, 999),     // dist = 1 (nearest)
+            ("chr1", 1, 2),       // dist = 998
+            ("chr1", 3, 4),       // dist = 996
+            ("chr1", 5, 6),       // dist = 994
+            ("chr1", 1020, 2000), // dist = 10
+        ]);
+        let result = a.closest(&b);
+        assert_eq!(result[0].2, 1);
+    }
+
+    #[rstest]
+    fn test_closest_nearest_far_right_of_insertion() {
+        let a = make_regionset(vec![("chr1", 500, 510)]);
+        let b = make_regionset(vec![
+            ("chr1", 0, 490),     // dist = 10
+            ("chr1", 520, 521),   // dist = 10
+            ("chr1", 522, 523),   // dist = 12
+            ("chr1", 524, 525),   // dist = 14
+            ("chr1", 526, 527),   // dist = 16
+            ("chr1", 528, 529),   // dist = 18
+            ("chr1", 530, 531),   // dist = 20
+            ("chr1", 508, 509),   // dist = 0 (overlap!)
+        ]);
+        // After sorting by start, the overlapping region should be found
+        let result = a.closest(&b);
+        assert_eq!(result[0].2, 0);
+    }
+
+    #[rstest]
+    fn test_closest_variable_density() {
+        let a = make_regionset(vec![("chr1", 5000, 5010)]);
+        let mut regions: Vec<(&str, u32, u32)> = Vec::new();
+        // 20 tiny regions clustered at the start
+        for i in 0..20 {
+            regions.push(("chr1", i * 2, i * 2 + 1));
+        }
+        // One region that's actually close
+        regions.push(("chr1", 4990, 4999)); // dist = 1
+        // Some regions after
+        regions.push(("chr1", 6000, 6001));
+        let b = make_regionset(regions);
+        let result = a.closest(&b);
+        assert_eq!(result[0].2, 1);
+    }
+
+    #[rstest]
+    fn test_closest_single_candidate() {
+        let a = make_regionset(vec![("chr1", 100, 200)]);
+        let b = make_regionset(vec![("chr1", 500, 600)]);
+        let result = a.closest(&b);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].2, 300);
+    }
+
+    #[rstest]
+    fn test_closest_wide_region_far_left() {
+        let a = make_regionset(vec![("chr1", 1000, 1010)]);
+        let b = make_regionset(vec![
+            ("chr1", 10, 998),    // dist = 2 (wide region, close end)
+            ("chr1", 500, 501),   // dist = 499
+            ("chr1", 600, 601),   // dist = 399
+            ("chr1", 700, 701),   // dist = 299
+            ("chr1", 1050, 1060), // dist = 40
+        ]);
+        let result = a.closest(&b);
+        assert_eq!(result[0].2, 2);
     }
 
     // ── cluster tests ──────────────────────────────────────────────────

--- a/gtars-genomicdist/src/signal.rs
+++ b/gtars-genomicdist/src/signal.rs
@@ -22,7 +22,7 @@ use crate::errors::GtarsGenomicDistError;
 /// Magic bytes for the packed signal matrix format: "SIGM" = 0x5349474D.
 const SIGM_MAGIC: u32 = 0x5349474D;
 /// Current version of the packed signal matrix format.
-const SIGM_VERSION: u32 = 1;
+const SIGM_VERSION: u32 = 2;
 
 /// A matrix of signal values across genomic regions and conditions.
 ///
@@ -225,15 +225,10 @@ impl SignalMatrix {
             buf.extend_from_slice(&region.end.to_le_bytes());
         }
 
-        // Values — flat row-major f64 array
-        // Write as raw bytes for maximum speed
-        let values_bytes = unsafe {
-            std::slice::from_raw_parts(
-                self.values.as_ptr() as *const u8,
-                self.values.len() * std::mem::size_of::<f64>(),
-            )
-        };
-        buf.extend_from_slice(values_bytes);
+        // Values — flat row-major f64 array, explicit little-endian encoding
+        for &v in &self.values {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
 
         let mut file = File::create(path)?;
         file.write_all(&buf)?;
@@ -288,8 +283,8 @@ impl SignalMatrix {
         let version = read_u32!();
         if version != SIGM_VERSION {
             return Err(err(&format!(
-                "Unsupported signal matrix format version {}",
-                version
+                "Unsupported signal matrix format version {} (expected {}) — regenerate with 'gtars prep'",
+                version, SIGM_VERSION
             )));
         }
         let n_regions = read_u32!() as usize;
@@ -341,17 +336,12 @@ impl SignalMatrix {
             });
         }
 
-        // Values — flat row-major f64 array (one big memcpy)
+        // Values — flat row-major f64 array, explicit little-endian decoding
         let n_values = n_regions * n_conditions;
-        let values_bytes = read_bytes!(n_values * 8);
-        let mut values = vec![0.0f64; n_values];
-        // Safety: copying raw bytes into properly sized Vec<f64>
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                values_bytes.as_ptr(),
-                values.as_mut_ptr() as *mut u8,
-                n_values * 8,
-            );
+        let mut values = Vec::with_capacity(n_values);
+        for _ in 0..n_values {
+            let bytes = read_bytes!(8);
+            values.push(f64::from_le_bytes(bytes.try_into().unwrap()));
         }
 
         Ok(SignalMatrix {
@@ -761,5 +751,149 @@ mod tests {
             Ok(_) => panic!("Expected error loading invalid file"),
         };
         assert!(msg.contains("regenerate"), "Error should mention regeneration: {}", msg);
+    }
+
+    /// Test that save_bin writes f64 values in little-endian byte order.
+    ///
+    /// We construct a SignalMatrix with a known f64 value (1.0), save it,
+    /// then scan the binary output for those bytes and verify they appear
+    /// in IEEE 754 little-endian encoding (0x3FF0000000000000 in LE = [0,0,0,0,0,0,F0,3F]).
+    #[rstest]
+    fn test_save_bin_f64_little_endian_encoding() {
+        // 1.0f64 in IEEE 754 little-endian bytes
+        let one_le: [u8; 8] = 1.0f64.to_le_bytes();
+
+        // Build a minimal 1-region, 1-condition SignalMatrix with value 1.0
+        use gtars_core::models::Region;
+        let regions = vec![Region {
+            chr: "chr1".to_string(),
+            start: 100,
+            end: 200,
+            rest: None,
+        }];
+        let sm = SignalMatrix {
+            regions: RegionSet::from(regions),
+            condition_names: vec!["cond_A".to_string()],
+            n_conditions: 1,
+            values: vec![1.0f64],
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let bin_path = dir.path().join("le_test.bin");
+        sm.save_bin(&bin_path).unwrap();
+
+        let data = std::fs::read(&bin_path).unwrap();
+
+        // Find the 8-byte little-endian encoding of 1.0 somewhere in the output
+        let found = data.windows(8).any(|w| w == one_le);
+        assert!(
+            found,
+            "Expected to find 1.0f64 in little-endian encoding {:?} in binary output, but did not. \
+             This indicates the f64 values are NOT written in little-endian byte order.",
+            one_le
+        );
+
+        // Also verify that the big-endian encoding of 1.0 does NOT appear
+        // (unless it coincidentally appears as part of another field, which is unlikely here)
+        let one_be: [u8; 8] = 1.0f64.to_be_bytes();
+        // Only check if LE and BE differ (they differ for 1.0)
+        if one_le != one_be {
+            let found_be = data.windows(8).any(|w| w == one_be);
+            assert!(
+                !found_be,
+                "Found 1.0f64 in big-endian encoding {:?} in binary output — values should be little-endian.",
+                one_be
+            );
+        }
+    }
+
+    /// Test that load_bin_from_bytes correctly interprets bytes as little-endian f64.
+    ///
+    /// We manually construct a minimal valid binary with a known f64 value
+    /// written in little-endian, and verify load_bin_from_bytes decodes it correctly.
+    #[rstest]
+    fn test_load_bin_from_bytes_f64_little_endian_decoding() {
+        // Build expected binary manually:
+        // header: magic(4) + version(4) + n_regions(4) + n_conditions(4) = 16 bytes
+        // intern table: n_strings(4) + len("chr1")(4) + "chr1"(4) + len("C")(4) + "C"(1) = 17 bytes
+        // condition names section: n_names(4) + id(2) = 6 bytes
+        // regions column-oriented: chr_ids(2) + starts(4) + ends(4) = 10 bytes
+        // values: 8 bytes (one f64)
+        let mut buf: Vec<u8> = Vec::new();
+
+        // Header
+        buf.extend_from_slice(&SIGM_MAGIC.to_le_bytes());
+        buf.extend_from_slice(&SIGM_VERSION.to_le_bytes());
+        buf.extend_from_slice(&1u32.to_le_bytes()); // n_regions = 1
+        buf.extend_from_slice(&1u32.to_le_bytes()); // n_conditions = 1
+
+        // Intern table: 2 strings: "chr1" (id=0), "C" (id=1)
+        buf.extend_from_slice(&2u32.to_le_bytes()); // n_strings
+        buf.extend_from_slice(&4u32.to_le_bytes()); // len("chr1")
+        buf.extend_from_slice(b"chr1");
+        buf.extend_from_slice(&1u32.to_le_bytes()); // len("C")
+        buf.extend_from_slice(b"C");
+
+        // Condition names: 1 name, id=1 ("C")
+        buf.extend_from_slice(&1u32.to_le_bytes()); // n_names
+        buf.extend_from_slice(&1u16.to_le_bytes()); // id of "C"
+
+        // Regions (column-oriented): chr_id=0, start=100, end=200
+        buf.extend_from_slice(&0u16.to_le_bytes()); // chr_id for region 0
+        buf.extend_from_slice(&100u32.to_le_bytes()); // start
+        buf.extend_from_slice(&200u32.to_le_bytes()); // end
+
+        // Values: 1 f64 = 3.14, written in little-endian
+        let pi: f64 = 3.14;
+        buf.extend_from_slice(&pi.to_le_bytes());
+
+        let sm = SignalMatrix::load_bin_from_bytes(&buf)
+            .expect("load_bin_from_bytes should succeed with valid little-endian data");
+
+        assert_eq!(sm.values.len(), 1);
+        assert!(
+            (sm.values[0] - pi).abs() < 1e-15,
+            "Expected value {} but got {} — load_bin_from_bytes may not be reading f64 as little-endian",
+            pi,
+            sm.values[0]
+        );
+        assert_eq!(sm.condition_names, vec!["C"]);
+        assert_eq!(sm.regions.regions[0].chr, "chr1");
+        assert_eq!(sm.regions.regions[0].start, 100);
+        assert_eq!(sm.regions.regions[0].end, 200);
+    }
+
+    /// Test that a file written with version 1 is rejected once SIGM_VERSION is bumped to 2.
+    ///
+    /// This test verifies the version-mismatch guard works. After bumping SIGM_VERSION
+    /// to 2, a file with version=1 in the header must be rejected with an error message
+    /// that mentions the mismatched version number (1) so users know to regenerate.
+    #[rstest]
+    fn test_signal_matrix_rejects_version_1_file() {
+        // Only meaningful once SIGM_VERSION > 1
+        if SIGM_VERSION == 1 {
+            // Pre-bump: this test is a sentinel; skip the assertion
+            return;
+        }
+
+        // Construct a minimal binary with SIGM_MAGIC but version=1 (old format)
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(&SIGM_MAGIC.to_le_bytes());
+        buf.extend_from_slice(&1u32.to_le_bytes()); // version 1 (old)
+        buf.extend_from_slice(&0u32.to_le_bytes()); // n_regions
+        buf.extend_from_slice(&0u32.to_le_bytes()); // n_conditions
+
+        let result = SignalMatrix::load_bin_from_bytes(&buf);
+        assert!(
+            result.is_err(),
+            "Expected error loading version-1 file when SIGM_VERSION={}",
+            SIGM_VERSION
+        );
+        let msg = format!("{}", result.err().unwrap());
+        assert!(
+            msg.contains("1"),
+            "Error message should mention the mismatched version number (1): {}",
+            msg
+        );
     }
 }

--- a/gtars-r/src/rust/src/genomicdist.rs
+++ b/gtars-r/src/rust/src/genomicdist.rs
@@ -46,27 +46,34 @@ macro_rules! with_partitions {
 // Helper functions
 // =========================================================================
 
+/// Convert an R signed integer to u32 with a clear error on negative values.
+fn checked_u32(value: i32, name: &str) -> extendr_api::Result<u32> {
+    u32::try_from(value).map_err(|_| {
+        extendr_api::Error::Other(format!("{} must be non-negative, got {}", name, value))
+    })
+}
+
 /// Construct RegionSet from R vectors (0-based half-open coordinates)
-fn regionset_from_vecs(chrs: Vec<String>, starts: Vec<i32>, ends: Vec<i32>) -> RegionSet {
+fn regionset_from_vecs(chrs: Vec<String>, starts: Vec<i32>, ends: Vec<i32>) -> extendr_api::Result<RegionSet> {
     let regions: Vec<Region> = chrs
         .into_iter()
         .zip(starts.into_iter().zip(ends.into_iter()))
-        .map(|(chr, (start, end))| Region {
+        .map(|(chr, (start, end))| Ok(Region {
             chr,
-            start: start as u32,
-            end: end as u32,
+            start: checked_u32(start, "start")?,
+            end: checked_u32(end, "end")?,
             rest: None,
-        })
-        .collect();
-    RegionSet::from(regions)
+        }))
+        .collect::<extendr_api::Result<Vec<Region>>>()?;
+    Ok(RegionSet::from(regions))
 }
 
 /// Build HashMap<String, u32> from parallel name/size vectors
-fn chrom_sizes_from_vecs(names: Vec<String>, sizes: Vec<i32>) -> HashMap<String, u32> {
+fn chrom_sizes_from_vecs(names: Vec<String>, sizes: Vec<i32>) -> extendr_api::Result<HashMap<String, u32>> {
     names
         .into_iter()
         .zip(sizes.into_iter())
-        .map(|(name, size)| (name, size as u32))
+        .map(|(name, size)| Ok((name, checked_u32(size, "chrom_size")?)))
         .collect()
 }
 
@@ -90,9 +97,9 @@ pub fn r_load_regionset(bed_path: &str) -> extendr_api::Result<Robj> {
 /// @param starts Integer vector of start positions (0-based)
 /// @param ends Integer vector of end positions (half-open)
 #[extendr(r_name = "regionset_from_vectors")]
-pub fn r_regionset_from_vectors(chrs: Vec<String>, starts: Vec<i32>, ends: Vec<i32>) -> Robj {
-    let rs = regionset_from_vecs(chrs, starts, ends);
-    ExternalPtr::new(rs).into()
+pub fn r_regionset_from_vectors(chrs: Vec<String>, starts: Vec<i32>, ends: Vec<i32>) -> extendr_api::Result<Robj> {
+    let rs = regionset_from_vecs(chrs, starts, ends)?;
+    Ok(ExternalPtr::new(rs).into())
 }
 
 /// Extract chr/start/end vectors from a RegionSet pointer
@@ -102,8 +109,8 @@ pub fn r_regionset_from_vectors(chrs: Vec<String>, starts: Vec<i32>, ends: Vec<i
 pub fn r_regionset_to_vectors(rs_ptr: Robj) -> extendr_api::Result<List> {
     with_regionset!(rs_ptr, rs, {
         let chrs: Vec<String> = rs.regions.iter().map(|r| r.chr.clone()).collect();
-        let starts: Vec<i32> = rs.regions.iter().map(|r| r.start as i32).collect();
-        let ends: Vec<i32> = rs.regions.iter().map(|r| r.end as i32).collect();
+        let starts: Vec<f64> = rs.regions.iter().map(|r| r.start as f64).collect();
+        let ends: Vec<f64> = rs.regions.iter().map(|r| r.end as f64).collect();
         Ok(list!(chr = chrs, start = starts, end = ends))
     })
 }
@@ -126,9 +133,9 @@ pub fn r_regionset_length(rs_ptr: Robj) -> extendr_api::Result<i32> {
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 #[extendr(r_name = "r_calc_widths")]
-pub fn r_calc_widths(rs_ptr: Robj) -> extendr_api::Result<Vec<i32>> {
+pub fn r_calc_widths(rs_ptr: Robj) -> extendr_api::Result<Vec<f64>> {
     with_regionset!(rs_ptr, rs, {
-        Ok(rs.calc_widths().into_iter().map(|w| w as i32).collect())
+        Ok(rs.calc_widths().into_iter().map(|w| w as f64).collect())
     })
 }
 
@@ -149,12 +156,12 @@ pub fn r_calc_neighbor_distances(rs_ptr: Robj) -> extendr_api::Result<Vec<f64>> 
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 #[extendr(r_name = "r_calc_nearest_neighbors")]
-pub fn r_calc_nearest_neighbors(rs_ptr: Robj) -> extendr_api::Result<Vec<i32>> {
+pub fn r_calc_nearest_neighbors(rs_ptr: Robj) -> extendr_api::Result<Vec<f64>> {
     with_regionset!(rs_ptr, rs, {
         let dists = rs
             .calc_nearest_neighbors()
             .map_err(|e| extendr_api::Error::Other(format!("{}", e)))?;
-        Ok(dists.into_iter().map(|d| d as i32).collect())
+        Ok(dists.into_iter().map(|d| d as f64).collect())
     })
 }
 
@@ -171,21 +178,21 @@ pub fn r_chromosome_statistics(rs_ptr: Robj) -> extendr_api::Result<List> {
         });
 
         let mut chr_names: Vec<String> = Vec::new();
-        let mut n_regions: Vec<i32> = Vec::new();
-        let mut start_pos: Vec<i32> = Vec::new();
-        let mut end_pos: Vec<i32> = Vec::new();
-        let mut min_len: Vec<i32> = Vec::new();
-        let mut max_len: Vec<i32> = Vec::new();
+        let mut n_regions: Vec<f64> = Vec::new();
+        let mut start_pos: Vec<f64> = Vec::new();
+        let mut end_pos: Vec<f64> = Vec::new();
+        let mut min_len: Vec<f64> = Vec::new();
+        let mut max_len: Vec<f64> = Vec::new();
         let mut mean_len: Vec<f64> = Vec::new();
         let mut median_len: Vec<f64> = Vec::new();
 
         for (chr, s) in &entries {
             chr_names.push(chr.clone());
-            n_regions.push(s.number_of_regions as i32);
-            start_pos.push(s.start_nucleotide_position as i32);
-            end_pos.push(s.end_nucleotide_position as i32);
-            min_len.push(s.minimum_region_length as i32);
-            max_len.push(s.maximum_region_length as i32);
+            n_regions.push(s.number_of_regions as f64);
+            start_pos.push(s.start_nucleotide_position as f64);
+            end_pos.push(s.end_nucleotide_position as f64);
+            min_len.push(s.minimum_region_length as f64);
+            max_len.push(s.maximum_region_length as f64);
             mean_len.push(s.mean_region_length);
             median_len.push(s.median_region_length);
         }
@@ -209,8 +216,9 @@ pub fn r_chromosome_statistics(rs_ptr: Robj) -> extendr_api::Result<List> {
 /// @param n_bins Number of bins (default 250)
 #[extendr(r_name = "r_region_distribution")]
 pub fn r_region_distribution(rs_ptr: Robj, n_bins: i32) -> extendr_api::Result<List> {
+    let n_bins_u32 = checked_u32(n_bins, "n_bins")?;
     with_regionset!(rs_ptr, rs, {
-        let dist = rs.region_distribution_with_bins(n_bins as u32);
+        let dist = rs.region_distribution_with_bins(n_bins_u32);
         let mut bins: Vec<_> = dist.into_values().collect();
         bins.sort_by(|a, b| {
             chrom_karyotype_key(&a.chr)
@@ -219,17 +227,17 @@ pub fn r_region_distribution(rs_ptr: Robj, n_bins: i32) -> extendr_api::Result<L
         });
 
         let mut chrs: Vec<String> = Vec::new();
-        let mut starts: Vec<i32> = Vec::new();
-        let mut ends: Vec<i32> = Vec::new();
-        let mut counts: Vec<i32> = Vec::new();
-        let mut rids: Vec<i32> = Vec::new();
+        let mut starts: Vec<f64> = Vec::new();
+        let mut ends: Vec<f64> = Vec::new();
+        let mut counts: Vec<f64> = Vec::new();
+        let mut rids: Vec<f64> = Vec::new();
 
         for bin in &bins {
             chrs.push(bin.chr.clone());
-            starts.push(bin.start as i32);
-            ends.push(bin.end as i32);
-            counts.push(bin.n as i32);
-            rids.push(bin.rid as i32);
+            starts.push(bin.start as f64);
+            ends.push(bin.end as f64);
+            counts.push(bin.n as f64);
+            rids.push(bin.rid as f64);
         }
 
         Ok(list!(
@@ -334,8 +342,8 @@ pub fn r_trim(
     chrom_names: Vec<String>,
     chrom_sizes: Vec<i32>,
 ) -> extendr_api::Result<Robj> {
+    let sizes = chrom_sizes_from_vecs(chrom_names, chrom_sizes)?;
     with_regionset!(rs_ptr, rs, {
-        let sizes = chrom_sizes_from_vecs(chrom_names, chrom_sizes);
         let trimmed = rs.trim(&sizes);
         Ok(ExternalPtr::new(trimmed).into())
     })
@@ -348,8 +356,10 @@ pub fn r_trim(
 /// @param downstream Bases downstream of start
 #[extendr(r_name = "r_promoters")]
 pub fn r_promoters(rs_ptr: Robj, upstream: i32, downstream: i32) -> extendr_api::Result<Robj> {
+    let upstream_u32 = checked_u32(upstream, "upstream")?;
+    let downstream_u32 = checked_u32(downstream, "downstream")?;
     with_regionset!(rs_ptr, rs, {
-        let result = rs.promoters(upstream as u32, downstream as u32);
+        let result = rs.promoters(upstream_u32, downstream_u32);
         Ok(ExternalPtr::new(result).into())
     })
 }
@@ -454,8 +464,9 @@ pub fn r_shift(rs_ptr: Robj, offset: i32) -> extendr_api::Result<Robj> {
 /// @param both If TRUE, flank on both sides of the anchor
 #[extendr(r_name = "r_flank")]
 pub fn r_flank(rs_ptr: Robj, width: i32, use_start: bool, both: bool) -> extendr_api::Result<Robj> {
+    let width_u32 = checked_u32(width, "width")?;
     with_regionset!(rs_ptr, rs, {
-        let result = rs.flank(width as u32, use_start, both);
+        let result = rs.flank(width_u32, use_start, both);
         Ok(ExternalPtr::new(result).into())
     })
 }
@@ -467,8 +478,9 @@ pub fn r_flank(rs_ptr: Robj, width: i32, use_start: bool, both: bool) -> extendr
 /// @param fix Anchor point: "start", "end", or "center"
 #[extendr(r_name = "r_resize")]
 pub fn r_resize(rs_ptr: Robj, width: i32, fix: &str) -> extendr_api::Result<Robj> {
+    let width_u32 = checked_u32(width, "width")?;
     with_regionset!(rs_ptr, rs, {
-        let result = rs.resize(width as u32, fix);
+        let result = rs.resize(width_u32, fix);
         Ok(ExternalPtr::new(result).into())
     })
 }
@@ -482,9 +494,9 @@ pub fn r_resize(rs_ptr: Robj, width: i32, fix: &str) -> extendr_api::Result<Robj
 #[extendr(r_name = "r_narrow")]
 pub fn r_narrow(rs_ptr: Robj, start: Robj, end: Robj, width: Robj) -> extendr_api::Result<Robj> {
     with_regionset!(rs_ptr, rs, {
-        let s = if start.is_na() { None } else { Some(i32::try_from(start).unwrap_or(1) as u32) };
-        let e = if end.is_na() { None } else { Some(i32::try_from(end).unwrap_or(1) as u32) };
-        let w = if width.is_na() { None } else { Some(i32::try_from(width).unwrap_or(1) as u32) };
+        let s = if start.is_na() { None } else { Some(checked_u32(i32::try_from(start).unwrap_or(1), "start")?) };
+        let e = if end.is_na() { None } else { Some(checked_u32(i32::try_from(end).unwrap_or(1), "end")?) };
+        let w = if width.is_na() { None } else { Some(checked_u32(i32::try_from(width).unwrap_or(1), "width")?) };
         let result = rs.narrow(s, e, w);
         Ok(ExternalPtr::new(result).into())
     })
@@ -540,9 +552,9 @@ pub fn r_consensus(rs_list: List) -> extendr_api::Result<List> {
     }
     let result = consensus(&sets);
     let chrs: Vec<String> = result.iter().map(|r| r.chr.clone()).collect();
-    let starts: Vec<i32> = result.iter().map(|r| r.start as i32).collect();
-    let ends: Vec<i32> = result.iter().map(|r| r.end as i32).collect();
-    let counts: Vec<i32> = result.iter().map(|r| r.count as i32).collect();
+    let starts: Vec<f64> = result.iter().map(|r| r.start as f64).collect();
+    let ends: Vec<f64> = result.iter().map(|r| r.end as f64).collect();
+    let counts: Vec<f64> = result.iter().map(|r| r.count as f64).collect();
     Ok(list!(chr = chrs, start = starts, end = ends, count = counts))
 }
 
@@ -606,9 +618,11 @@ pub fn r_partition_list_from_regions(
     let sizes = if chrom_names.is_empty() {
         None
     } else {
-        Some(chrom_sizes_from_vecs(chrom_names, chrom_sizes_vec))
+        Some(chrom_sizes_from_vecs(chrom_names, chrom_sizes_vec)?)
     };
-    let pl = genome_partition_list(&model, core_prom as u32, prox_prom as u32, sizes.as_ref());
+    let core_prom_u32 = checked_u32(core_prom, "core_prom")?;
+    let prox_prom_u32 = checked_u32(prox_prom, "prox_prom")?;
+    let pl = genome_partition_list(&model, core_prom_u32, prox_prom_u32, sizes.as_ref());
     Ok(ExternalPtr::new(pl).into())
 }
 
@@ -663,16 +677,16 @@ pub fn r_partition_list_from_regions_stranded(
             .collect()
     };
 
-    let genes_rs = regionset_from_vecs(genes_chrs, genes_starts, genes_ends);
+    let genes_rs = regionset_from_vecs(genes_chrs, genes_starts, genes_ends)?;
     let genes_srs = StrandedRegionSet::new(genes_rs, parse_strands(genes_strands)).reduce();
 
-    let exons_rs = regionset_from_vecs(exons_chrs, exons_starts, exons_ends);
+    let exons_rs = regionset_from_vecs(exons_chrs, exons_starts, exons_ends)?;
     let exons_srs = StrandedRegionSet::new(exons_rs, parse_strands(exons_strands)).reduce();
 
     let three_utr = if three_utr_chrs.is_empty() {
         None
     } else {
-        let rs = regionset_from_vecs(three_utr_chrs, three_utr_starts, three_utr_ends);
+        let rs = regionset_from_vecs(three_utr_chrs, three_utr_starts, three_utr_ends)?;
         let srs = StrandedRegionSet::new(rs, parse_strands(three_utr_strands)).reduce();
         if srs.is_empty() { None } else { Some(srs) }
     };
@@ -680,7 +694,7 @@ pub fn r_partition_list_from_regions_stranded(
     let five_utr = if five_utr_chrs.is_empty() {
         None
     } else {
-        let rs = regionset_from_vecs(five_utr_chrs, five_utr_starts, five_utr_ends);
+        let rs = regionset_from_vecs(five_utr_chrs, five_utr_starts, five_utr_ends)?;
         let srs = StrandedRegionSet::new(rs, parse_strands(five_utr_strands)).reduce();
         if srs.is_empty() { None } else { Some(srs) }
     };
@@ -695,9 +709,11 @@ pub fn r_partition_list_from_regions_stranded(
     let sizes = if chrom_names.is_empty() {
         None
     } else {
-        Some(chrom_sizes_from_vecs(chrom_names, chrom_sizes_vec))
+        Some(chrom_sizes_from_vecs(chrom_names, chrom_sizes_vec)?)
     };
-    let pl = genome_partition_list(&model, core_prom as u32, prox_prom as u32, sizes.as_ref());
+    let core_prom_u32 = checked_u32(core_prom, "core_prom")?;
+    let prox_prom_u32 = checked_u32(prox_prom, "prox_prom")?;
+    let pl = genome_partition_list(&model, core_prom_u32, prox_prom_u32, sizes.as_ref());
     Ok(ExternalPtr::new(pl).into())
 }
 
@@ -725,9 +741,11 @@ pub fn r_partition_list_from_gtf(
     let sizes = if chrom_names.is_empty() {
         None
     } else {
-        Some(chrom_sizes_from_vecs(chrom_names, chrom_sizes_vec))
+        Some(chrom_sizes_from_vecs(chrom_names, chrom_sizes_vec)?)
     };
-    let pl = genome_partition_list(&model, core_prom as u32, prox_prom as u32, sizes.as_ref());
+    let core_prom_u32 = checked_u32(core_prom, "core_prom")?;
+    let prox_prom_u32 = checked_u32(prox_prom, "prox_prom")?;
+    let pl = genome_partition_list(&model, core_prom_u32, prox_prom_u32, sizes.as_ref());
     Ok(ExternalPtr::new(pl).into())
 }
 
@@ -746,11 +764,11 @@ pub fn r_calc_partitions(
         with_partitions!(partition_ptr, pl, {
             let result = calc_partitions(rs, pl, bp_proportion);
             let names: Vec<String> = result.counts.iter().map(|(n, _)| n.clone()).collect();
-            let counts: Vec<i32> = result.counts.iter().map(|(_, c)| *c as i32).collect();
+            let counts: Vec<f64> = result.counts.iter().map(|(_, c)| *c as f64).collect();
             Ok(list!(
                 partition = names,
                 count = counts,
-                total = result.total as i32
+                total = result.total as f64
             ))
         })
     })
@@ -771,9 +789,9 @@ pub fn r_calc_expected_partitions(
     chrom_sizes: Vec<i32>,
     bp_proportion: bool,
 ) -> extendr_api::Result<List> {
+    let sizes = chrom_sizes_from_vecs(chrom_names, chrom_sizes)?;
     with_regionset!(rs_ptr, rs, {
         with_partitions!(partition_ptr, pl, {
-            let sizes = chrom_sizes_from_vecs(chrom_names, chrom_sizes);
             let result = calc_expected_partitions(rs, pl, &sizes, bp_proportion);
             let partitions: Vec<String> = result.rows.iter().map(|r| r.partition.clone()).collect();
             let observed: Vec<f64> = result.rows.iter().map(|r| r.observed).collect();
@@ -998,9 +1016,11 @@ pub fn r_gda_partition_list(
     let sizes = if chrom_names.is_empty() {
         None
     } else {
-        Some(chrom_sizes_from_vecs(chrom_names, chrom_sizes_vec))
+        Some(chrom_sizes_from_vecs(chrom_names, chrom_sizes_vec)?)
     };
-    let pl = genome_partition_list(&ext_ptr.gene_model, core_prom as u32, prox_prom as u32, sizes.as_ref());
+    let core_prom_u32 = checked_u32(core_prom, "core_prom")?;
+    let prox_prom_u32 = checked_u32(prox_prom, "prox_prom")?;
+    let pl = genome_partition_list(&ext_ptr.gene_model, core_prom_u32, prox_prom_u32, sizes.as_ref());
     Ok(ExternalPtr::new(pl).into())
 }
 
@@ -1158,4 +1178,112 @@ extendr_module! {
     fn r_load_signal_matrix_bin;
     fn r_load_signal_matrix_tsv;
     fn r_calc_summary_signal_from_matrix;
+}
+
+// =========================================================================
+// Unit tests (pure Rust, no R runtime needed)
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- checked_u32 helper tests ---
+
+    #[test]
+    fn test_checked_u32_zero() {
+        assert_eq!(checked_u32(0, "x").unwrap(), 0u32);
+    }
+
+    #[test]
+    fn test_checked_u32_positive() {
+        assert_eq!(checked_u32(42, "x").unwrap(), 42u32);
+    }
+
+    #[test]
+    fn test_checked_u32_max_i32() {
+        assert_eq!(checked_u32(i32::MAX, "x").unwrap(), i32::MAX as u32);
+    }
+
+    #[test]
+    fn test_checked_u32_negative_one() {
+        let err = checked_u32(-1, "start").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("start"), "error should name the parameter");
+        assert!(msg.contains("-1"), "error should include the value");
+    }
+
+    #[test]
+    fn test_checked_u32_min_i32() {
+        let err = checked_u32(i32::MIN, "end").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("end"));
+        assert!(msg.contains(&i32::MIN.to_string()));
+    }
+
+    // --- regionset_from_vecs tests ---
+
+    #[test]
+    fn test_regionset_from_vecs_valid() {
+        let rs = regionset_from_vecs(
+            vec!["chr1".into(), "chr2".into()],
+            vec![0, 100],
+            vec![50, 200],
+        )
+        .unwrap();
+        assert_eq!(rs.regions.len(), 2);
+        assert_eq!(rs.regions[0].start, 0);
+        assert_eq!(rs.regions[0].end, 50);
+        assert_eq!(rs.regions[1].start, 100);
+        assert_eq!(rs.regions[1].end, 200);
+    }
+
+    #[test]
+    fn test_regionset_from_vecs_negative_start() {
+        let result = regionset_from_vecs(
+            vec!["chr1".into()],
+            vec![-5],
+            vec![100],
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("start"));
+        assert!(msg.contains("-5"));
+    }
+
+    #[test]
+    fn test_regionset_from_vecs_negative_end() {
+        let result = regionset_from_vecs(
+            vec!["chr1".into()],
+            vec![0],
+            vec![-1],
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("end"));
+    }
+
+    // --- chrom_sizes_from_vecs tests ---
+
+    #[test]
+    fn test_chrom_sizes_from_vecs_valid() {
+        let sizes = chrom_sizes_from_vecs(
+            vec!["chr1".into(), "chr2".into()],
+            vec![248956422, 242193529],
+        )
+        .unwrap();
+        assert_eq!(sizes["chr1"], 248956422);
+        assert_eq!(sizes["chr2"], 242193529);
+    }
+
+    #[test]
+    fn test_chrom_sizes_from_vecs_negative() {
+        let result = chrom_sizes_from_vecs(
+            vec!["chr1".into()],
+            vec![-100],
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("chrom_size"));
+    }
 }

--- a/gtars-wasm/src/regionset.rs
+++ b/gtars-wasm/src/regionset.rs
@@ -196,14 +196,15 @@ impl JsRegionSet {
     }
 
     #[wasm_bindgen(getter, js_name = "classify")]
-    pub fn classify_bed_js(&self) -> JsBedClassificationOutput {
-        let output = classify_bed(&self.region_set).unwrap();
-        JsBedClassificationOutput {
+    pub fn classify_bed_js(&self) -> Result<JsBedClassificationOutput, JsValue> {
+        let output = classify_bed(&self.region_set)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        Ok(JsBedClassificationOutput {
             bed_compliance: output.bed_compliance.clone(),
             data_format: format!("{:#?}", output.data_format),
             compliant_columns: output.compliant_columns,
             non_compliant_columns: output.non_compliant_columns,
-        }
+        })
     }
 
     // ── Statistics methods ───────────────────────────────────────────


### PR DESCRIPTION
- Fix closest() nearest-neighbor search to use bidirectional expanding scan instead of fixed ±2 window that missed true nearest neighbors (5 new tests)
- Replace unsafe native-endian f64 serialization in signal.rs with safe explicit little-endian encoding, bump SIGM_VERSION to 2 (3 new tests)
- Fix WASM classify_bed_js to return Result instead of panicking on error
- Fix R binding integer casts: add checked_u32 helper for i32→u32 inputs, change outputs from Vec<i32> to Vec<f64> to prevent truncation (10 new tests)