### PR TITLE
Binding alignment: Option cleanup, calc_gc_content, unified calc_dinucl_freq, R type casts

### DIFF
--- a/gtars-cli/src/genomicdist/cli.rs
+++ b/gtars-cli/src/genomicdist/cli.rs
@@ -56,6 +56,12 @@ pub fn create_genomicdist_cli() -> Command {
                 .help("When computing GC content, skip regions on chromosomes not in the FASTA (default: error)"),
         )
         .arg(
+            Arg::new("dinucl-raw-counts")
+                .long("dinucl-raw-counts")
+                .action(clap::ArgAction::SetTrue)
+                .help("Return raw per-region dinucleotide counts instead of percentages (matches R GenomicDistributions' rawCounts=TRUE)"),
+        )
+        .arg(
             Arg::new("promoter-upstream")
                 .long("promoter-upstream")
                 .required(false)

--- a/gtars-cli/src/genomicdist/cli.rs
+++ b/gtars-cli/src/genomicdist/cli.rs
@@ -44,6 +44,18 @@ pub fn create_genomicdist_cli() -> Command {
                 .help("Path to open signal matrix TSV (enables cell-type open chromatin enrichment)"),
         )
         .arg(
+            Arg::new("fasta")
+                .long("fasta")
+                .required(false)
+                .help("Path to genome FASTA file (enables GC content + dinucleotide frequencies)"),
+        )
+        .arg(
+            Arg::new("ignore-unk-chroms")
+                .long("ignore-unk-chroms")
+                .action(clap::ArgAction::SetTrue)
+                .help("When computing GC content, skip regions on chromosomes not in the FASTA (default: error)"),
+        )
+        .arg(
             Arg::new("promoter-upstream")
                 .long("promoter-upstream")
                 .required(false)

--- a/gtars-cli/src/genomicdist/handlers.rs
+++ b/gtars-cli/src/genomicdist/handlers.rs
@@ -15,7 +15,7 @@ use gtars_genomicdist::{
     GeneModel, GenomicDistAnnotation, ExpectedPartitionResult, PartitionResult,
     calc_expected_partitions, calc_partitions, genome_partition_list,
     SignalMatrix, calc_summary_signal, ConditionStats,
-    calc_gc_content, calc_dinucl_freq, calc_dinucl_freq_per_region, DINUCL_ORDER,
+    calc_gc_content, calc_dinucl_freq, DINUCL_ORDER,
     median_abs_distance,
 };
 
@@ -32,9 +32,7 @@ struct GenomicDistOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     gc_content: Option<GcContentOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    dinucl_freq: Option<HashMap<String, u64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    dinucl_freq_per_region: Option<DinuclFreqPerRegionOutput>,
+    dinucl_freq: Option<DinuclFreqOutput>,
 }
 
 #[derive(Serialize)]
@@ -46,13 +44,17 @@ struct GcContentOutput {
 }
 
 #[derive(Serialize)]
-struct DinuclFreqPerRegionOutput {
+struct DinuclFreqOutput {
     /// Dinucleotide names in canonical order (matches DINUCL_ORDER)
     dinucleotides: Vec<String>,
     /// `chr_start_end` label per region
     region_labels: Vec<String>,
-    /// Frequency matrix: outer is regions, inner is percentages per dinucleotide
+    /// Per-region matrix: outer is regions, inner is 16 values matching
+    /// `dinucleotides` order. Percentages (0–100) by default, or raw counts
+    /// if --dinucl-raw-counts flag was passed.
     frequencies: Vec<[f64; 16]>,
+    /// Whether `frequencies` are raw counts (true) or percentages (false)
+    raw_counts: bool,
 }
 
 #[derive(Serialize)]
@@ -257,7 +259,8 @@ pub fn run_genomicdist(matches: &ArgMatches) -> Result<()> {
     };
 
     // --- Optional: GC content + dinucleotide frequencies (require FASTA) ---
-    let (gc_content_out, dinucl_freq_out, dinucl_per_region_out) = match fasta_path {
+    let dinucl_raw_counts = matches.get_flag("dinucl-raw-counts");
+    let (gc_content_out, dinucl_freq_out) = match fasta_path {
         Some(p) => {
             let assembly = GenomeAssembly::try_from(p.as_str())
                 .map_err(|e| anyhow::anyhow!("Failed to load FASTA: {}", e))?;
@@ -273,28 +276,20 @@ pub fn run_genomicdist(matches: &ArgMatches) -> Result<()> {
                 per_region: gc_per_region,
             };
 
-            let dinucl_global = calc_dinucl_freq(&rs, &assembly)
+            let (labels, matrix) = calc_dinucl_freq(&rs, &assembly, dinucl_raw_counts)
                 .map_err(|e| anyhow::anyhow!("Failed to compute dinucl freq: {}", e))?;
-            // Convert Dinucleotide keys to strings, ordered canonically
-            let mut dinucl_global_map: HashMap<String, u64> = HashMap::new();
-            for dn in DINUCL_ORDER.iter() {
-                let count = dinucl_global.get(dn).copied().unwrap_or(0);
-                dinucl_global_map.insert(dn.to_string().unwrap_or_default(), count);
-            }
-
-            let (labels, matrix) = calc_dinucl_freq_per_region(&rs, &assembly)
-                .map_err(|e| anyhow::anyhow!("Failed to compute dinucl freq per region: {}", e))?;
-            let per_region = DinuclFreqPerRegionOutput {
+            let dinucl_out = DinuclFreqOutput {
                 dinucleotides: DINUCL_ORDER
                     .iter()
                     .map(|d| d.to_string().unwrap_or_default())
                     .collect(),
                 region_labels: labels,
                 frequencies: matrix,
+                raw_counts: dinucl_raw_counts,
             };
-            (Some(gc_out), Some(dinucl_global_map), Some(per_region))
+            (Some(gc_out), Some(dinucl_out))
         }
-        None => (None, None, None),
+        None => (None, None),
     };
 
     // --- Build output ---
@@ -317,7 +312,6 @@ pub fn run_genomicdist(matches: &ArgMatches) -> Result<()> {
         open_signal,
         gc_content: gc_content_out,
         dinucl_freq: dinucl_freq_out,
-        dinucl_freq_per_region: dinucl_per_region_out,
     };
 
     let compact = matches.get_flag("compact");

--- a/gtars-cli/src/genomicdist/handlers.rs
+++ b/gtars-cli/src/genomicdist/handlers.rs
@@ -9,12 +9,13 @@ use serde::Serialize;
 
 use gtars_core::models::{Region, RegionSet};
 use gtars_core::utils::get_chrom_sizes;
-use gtars_genomicdist::models::{ChromosomeStatistics, RegionBin, Strand, TssIndex};
+use gtars_genomicdist::models::{ChromosomeStatistics, GenomeAssembly, RegionBin, Strand, TssIndex};
 use gtars_genomicdist::statistics::GenomicIntervalSetStatistics;
 use gtars_genomicdist::{
     GeneModel, GenomicDistAnnotation, ExpectedPartitionResult, PartitionResult,
     calc_expected_partitions, calc_partitions, genome_partition_list,
     SignalMatrix, calc_summary_signal, ConditionStats,
+    calc_gc_content, calc_dinucl_freq, calc_dinucl_freq_per_region, DINUCL_ORDER,
     median_abs_distance,
 };
 
@@ -28,6 +29,30 @@ struct GenomicDistOutput {
     expected_partitions: Option<ExpectedPartitionResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     open_signal: Option<OpenSignalOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gc_content: Option<GcContentOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dinucl_freq: Option<HashMap<String, u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dinucl_freq_per_region: Option<DinuclFreqPerRegionOutput>,
+}
+
+#[derive(Serialize)]
+struct GcContentOutput {
+    /// Mean GC content across all regions (0–1)
+    mean: f64,
+    /// Per-region GC content values (0–1), one per region in input order
+    per_region: Vec<f64>,
+}
+
+#[derive(Serialize)]
+struct DinuclFreqPerRegionOutput {
+    /// Dinucleotide names in canonical order (matches DINUCL_ORDER)
+    dinucleotides: Vec<String>,
+    /// `chr_start_end` label per region
+    region_labels: Vec<String>,
+    /// Frequency matrix: outer is regions, inner is percentages per dinucleotide
+    frequencies: Vec<[f64; 16]>,
 }
 
 #[derive(Serialize)]
@@ -65,6 +90,8 @@ pub fn run_genomicdist(matches: &ArgMatches) -> Result<()> {
     let chrom_sizes_path = matches.get_one::<String>("chrom-sizes");
     let output_path = matches.get_one::<String>("output");
     let signal_matrix_path = matches.get_one::<String>("signal-matrix");
+    let fasta_path = matches.get_one::<String>("fasta");
+    let ignore_unk_chroms = matches.get_flag("ignore-unk-chroms");
     let n_bins: u32 = matches
         .get_one::<String>("bins")
         .unwrap()
@@ -229,6 +256,47 @@ pub fn run_genomicdist(matches: &ArgMatches) -> Result<()> {
         None => None,
     };
 
+    // --- Optional: GC content + dinucleotide frequencies (require FASTA) ---
+    let (gc_content_out, dinucl_freq_out, dinucl_per_region_out) = match fasta_path {
+        Some(p) => {
+            let assembly = GenomeAssembly::try_from(p.as_str())
+                .map_err(|e| anyhow::anyhow!("Failed to load FASTA: {}", e))?;
+            let gc_per_region = calc_gc_content(&rs, &assembly, ignore_unk_chroms)
+                .map_err(|e| anyhow::anyhow!("Failed to compute GC content: {}", e))?;
+            let gc_mean = if gc_per_region.is_empty() {
+                0.0
+            } else {
+                gc_per_region.iter().sum::<f64>() / gc_per_region.len() as f64
+            };
+            let gc_out = GcContentOutput {
+                mean: gc_mean,
+                per_region: gc_per_region,
+            };
+
+            let dinucl_global = calc_dinucl_freq(&rs, &assembly)
+                .map_err(|e| anyhow::anyhow!("Failed to compute dinucl freq: {}", e))?;
+            // Convert Dinucleotide keys to strings, ordered canonically
+            let mut dinucl_global_map: HashMap<String, u64> = HashMap::new();
+            for dn in DINUCL_ORDER.iter() {
+                let count = dinucl_global.get(dn).copied().unwrap_or(0);
+                dinucl_global_map.insert(dn.to_string().unwrap_or_default(), count);
+            }
+
+            let (labels, matrix) = calc_dinucl_freq_per_region(&rs, &assembly)
+                .map_err(|e| anyhow::anyhow!("Failed to compute dinucl freq per region: {}", e))?;
+            let per_region = DinuclFreqPerRegionOutput {
+                dinucleotides: DINUCL_ORDER
+                    .iter()
+                    .map(|d| d.to_string().unwrap_or_default())
+                    .collect(),
+                region_labels: labels,
+                frequencies: matrix,
+            };
+            (Some(gc_out), Some(dinucl_global_map), Some(per_region))
+        }
+        None => (None, None, None),
+    };
+
     // --- Build output ---
     let output = GenomicDistOutput {
         scalars: Scalars {
@@ -247,6 +315,9 @@ pub fn run_genomicdist(matches: &ArgMatches) -> Result<()> {
         },
         expected_partitions,
         open_signal,
+        gc_content: gc_content_out,
+        dinucl_freq: dinucl_freq_out,
+        dinucl_freq_per_region: dinucl_per_region_out,
     };
 
     let compact = matches.get_flag("compact");

--- a/gtars-genomicdist/src/lib.rs
+++ b/gtars-genomicdist/src/lib.rs
@@ -50,4 +50,4 @@ pub use models::{SortedRegionSet, Strand, StrandedRegionSet};
 pub use signal::{calc_summary_signal, ConditionStats, SignalMatrix, SignalSummaryResult};
 pub use statistics::GenomicIntervalSetStatistics;
 pub use utils::{chrom_karyotype_key, median_abs_distance};
-pub use statistics::{calc_dinucl_freq, calc_dinucl_freq_per_region, calc_gc_content, DINUCL_ORDER};
+pub use statistics::{calc_dinucl_freq, calc_gc_content, DINUCL_ORDER};

--- a/gtars-genomicdist/src/statistics.rs
+++ b/gtars-genomicdist/src/statistics.rs
@@ -52,7 +52,12 @@ pub trait GenomicIntervalSetStatistics {
     /// For each pair of adjacent regions on the same chromosome, returns the
     /// signed gap: `next.start - current.end`. Positive values indicate a gap,
     /// negative values indicate overlapping regions, zero means adjacent/abutting.
-    /// Regions on chromosomes with fewer than 2 regions are skipped.
+    ///
+    /// Regions on chromosomes with fewer than 2 regions are skipped (they have
+    /// no neighbors to measure against). Output length equals the total number
+    /// of *gaps* across all multi-region chromosomes — generally shorter than
+    /// the input region count. Output is not aligned 1:1 with input regions.
+    /// No sentinel values are emitted.
     fn calc_neighbor_distances(&self) -> Result<Vec<i64>, GtarsGenomicDistError>;
 
     /// Compute the distance from each region to its nearest neighbor.
@@ -60,6 +65,13 @@ pub trait GenomicIntervalSetStatistics {
     /// For each region, takes the minimum absolute distance to its upstream
     /// and downstream neighbors. First and last regions on each chromosome
     /// use their only neighbor's distance. Overlapping neighbors have distance 0.
+    ///
+    /// Regions on chromosomes with only one region are skipped (they have no
+    /// neighbors). Output length equals the total number of regions across all
+    /// multi-region chromosomes — generally shorter than the input region
+    /// count, and NOT aligned 1:1 with input regions. No sentinel values are
+    /// emitted. Callers who need 1:1 alignment must filter their input to
+    /// multi-region chromosomes first.
     ///
     /// Port of R GenomicDistributions `calcNearestNeighbors()`.
     fn calc_nearest_neighbors(&self) -> Result<Vec<u32>, GtarsGenomicDistError>;

--- a/gtars-genomicdist/src/statistics.rs
+++ b/gtars-genomicdist/src/statistics.rs
@@ -363,38 +363,6 @@ pub fn calc_gc_content(
     Ok(gc_contents)
 }
 
-///
-///  Calculate Dinucleotide frequencies
-///
-/// Arguments:
-/// - region_set: RegionSet object
-/// - genome: GenomeAssembly object (reference genome)
-/// Return: Result of hashmap of dinucleotide and frequencies e.g. 'Aa: 13142'
-pub fn calc_dinucl_freq(
-    region_set: &RegionSet,
-    genome: &GenomeAssembly,
-) -> Result<HashMap<Dinucleotide, u64>, GtarsGenomicDistError> {
-    let mut dinucl_freqs: HashMap<Dinucleotide, u64> = HashMap::new();
-
-    for chr in region_set.iter_chroms() {
-        for region in region_set.iter_chr_regions(chr) {
-            let seq = genome.seq_from_region(region)?;
-            for aas in seq.windows(2) {
-                let dinucl = Dinucleotide::from_bytes(aas);
-                match dinucl {
-                    Some(dinucl) => {
-                        let current_freq = dinucl_freqs.entry(dinucl).or_insert(0);
-                        *current_freq += 1;
-                    }
-                    None => continue,
-                }
-            }
-        }
-    }
-
-    Ok(dinucl_freqs)
-}
-
 /// Canonical ordering of dinucleotides, matching GenomicDistributions' column order.
 pub const DINUCL_ORDER: [Dinucleotide; 16] = [
     Dinucleotide::Aa, Dinucleotide::Ac, Dinucleotide::Ag, Dinucleotide::At,
@@ -403,17 +371,41 @@ pub const DINUCL_ORDER: [Dinucleotide; 16] = [
     Dinucleotide::Ta, Dinucleotide::Tc, Dinucleotide::Tg, Dinucleotide::Tt,
 ];
 
-/// Per-region dinucleotide frequencies as percentages.
+/// Per-region dinucleotide frequencies.
 ///
-/// Returns a tuple of (region_labels, frequency_matrix) where:
-/// - `region_labels` is `chr_start_end` for each region
-/// - `frequency_matrix` is a `Vec<[f64; 16]>` — one row per region, columns
-///   in [`DINUCL_ORDER`] order, values are percentages (0–100).
+/// Matches R GenomicDistributions `calcDinuclFreq`: one row per region,
+/// 16 dinucleotide columns in [`DINUCL_ORDER`] order.
 ///
-/// This matches the output format of R's GenomicDistributions::calcDinuclFreq.
-pub fn calc_dinucl_freq_per_region(
+/// Arguments:
+/// - `region_set`: RegionSet object
+/// - `genome`: GenomeAssembly object (reference genome)
+/// - `raw_counts`: if `true`, return raw integer-valued counts;
+///   if `false`, return percentages (0–100) per row (matches R default)
+///
+/// Returns a tuple `(region_labels, frequency_matrix)`:
+/// - `region_labels`: `chr_start_end` for each region
+/// - `frequency_matrix`: `Vec<[f64; 16]>` — one row per region
+///
+/// For pooled global counts across all regions, sum the columns of the
+/// raw-counts matrix:
+/// ```no_run
+/// # use gtars_genomicdist::{calc_dinucl_freq, DINUCL_ORDER};
+/// # use gtars_genomicdist::models::GenomeAssembly;
+/// # use gtars_core::models::RegionSet;
+/// # fn example(rs: &RegionSet, assembly: &GenomeAssembly) -> Result<(), Box<dyn std::error::Error>> {
+/// let (_, matrix) = calc_dinucl_freq(rs, assembly, true)?;
+/// let mut totals = [0.0f64; 16];
+/// for row in &matrix {
+///     for (i, &c) in row.iter().enumerate() {
+///         totals[i] += c;
+///     }
+/// }
+/// # Ok(()) }
+/// ```
+pub fn calc_dinucl_freq(
     region_set: &RegionSet,
     genome: &GenomeAssembly,
+    raw_counts: bool,
 ) -> Result<(Vec<String>, Vec<[f64; 16]>), GtarsGenomicDistError> {
     let mut labels: Vec<String> = Vec::new();
     let mut matrix: Vec<[f64; 16]> = Vec::new();
@@ -432,19 +424,25 @@ pub fn calc_dinucl_freq_per_region(
                 }
             }
 
-            let freqs: [f64; 16] = if total > 0 {
-                let mut f = [0.0f64; 16];
+            let row: [f64; 16] = if raw_counts {
+                let mut r = [0.0f64; 16];
                 for (i, &c) in counts.iter().enumerate() {
-                    f[i] = (c as f64 / total as f64) * 100.0;
+                    r[i] = c as f64;
                 }
-                f
+                r
+            } else if total > 0 {
+                let mut r = [0.0f64; 16];
+                for (i, &c) in counts.iter().enumerate() {
+                    r[i] = (c as f64 / total as f64) * 100.0;
+                }
+                r
             } else {
                 [0.0; 16]
             };
 
             labels.push(format!("{}_{}_{}",
                 region.chr, region.start, region.end));
-            matrix.push(freqs);
+            matrix.push(row);
         }
     }
 
@@ -598,8 +596,8 @@ mod tests {
     // --- Dinucleotide frequency ---
 
     #[rstest]
-    fn test_calc_dinucl_freq() {
-        // base.fa: chr1=GGAA → dinucleotides: GG, GA, AA
+    fn test_calc_dinucl_freq_raw_counts() {
+        // base.fa: chr1=GGAA → dinucleotides: GG, GA, AA (3 total)
         let path = get_fasta_path("base.fa");
         let ga = GenomeAssembly::try_from(path.to_str().unwrap()).unwrap();
 
@@ -607,19 +605,25 @@ mod tests {
             Region { chr: "chr1".into(), start: 0, end: 4, rest: None },
         ];
         let rs = RegionSet::from(regions);
-        let freq = calc_dinucl_freq(&rs, &ga).unwrap();
+        let (labels, matrix) = calc_dinucl_freq(&rs, &ga, true).unwrap();
 
-        assert_eq!(*freq.get(&Dinucleotide::Gg).unwrap_or(&0), 1);
-        assert_eq!(*freq.get(&Dinucleotide::Ga).unwrap_or(&0), 1);
-        assert_eq!(*freq.get(&Dinucleotide::Aa).unwrap_or(&0), 1);
+        assert_eq!(labels, vec!["chr1_0_4"]);
+        assert_eq!(matrix.len(), 1);
+        let row = &matrix[0];
+        let gg_idx = DINUCL_ORDER.iter().position(|d| *d == Dinucleotide::Gg).unwrap();
+        let ga_idx = DINUCL_ORDER.iter().position(|d| *d == Dinucleotide::Ga).unwrap();
+        let aa_idx = DINUCL_ORDER.iter().position(|d| *d == Dinucleotide::Aa).unwrap();
+        assert_eq!(row[gg_idx], 1.0);
+        assert_eq!(row[ga_idx], 1.0);
+        assert_eq!(row[aa_idx], 1.0);
         // total should be 3 (4 bases → 3 dinucleotides)
-        let total: u64 = freq.values().sum();
-        assert_eq!(total, 3);
+        let total: f64 = row.iter().sum();
+        assert_eq!(total, 3.0);
     }
 
     #[rstest]
-    fn test_calc_dinucl_freq_per_region() {
-        // base.fa: chr2=GCGC → dinucleotides: GC, CG, GC
+    fn test_calc_dinucl_freq_percentages() {
+        // base.fa: chr2=GCGC → dinucleotides: GC, CG, GC (percentages)
         let path = get_fasta_path("base.fa");
         let ga = GenomeAssembly::try_from(path.to_str().unwrap()).unwrap();
 
@@ -627,14 +631,13 @@ mod tests {
             Region { chr: "chr2".into(), start: 0, end: 4, rest: None },
         ];
         let rs = RegionSet::from(regions);
-        let (labels, matrix) = calc_dinucl_freq_per_region(&rs, &ga).unwrap();
+        let (labels, matrix) = calc_dinucl_freq(&rs, &ga, false).unwrap();
 
         assert_eq!(labels.len(), 1);
         assert_eq!(labels[0], "chr2_0_4");
         assert_eq!(matrix.len(), 1);
 
         // GC appears 2/3 times, CG appears 1/3 times
-        // Find indices in DINUCL_ORDER
         let gc_idx = DINUCL_ORDER.iter().position(|d| *d == Dinucleotide::Gc).unwrap();
         let cg_idx = DINUCL_ORDER.iter().position(|d| *d == Dinucleotide::Cg).unwrap();
 
@@ -642,9 +645,32 @@ mod tests {
         assert!((row[gc_idx] - 200.0 / 3.0).abs() < 0.1); // ~66.67%
         assert!((row[cg_idx] - 100.0 / 3.0).abs() < 0.1);  // ~33.33%
 
-        // all other dinucleotides should be 0
+        // percentages sum to 100
         let total: f64 = row.iter().sum();
         assert!((total - 100.0).abs() < 0.1);
+    }
+
+    #[rstest]
+    fn test_calc_dinucl_freq_global_derivable() {
+        // Global counts are derivable by column-summing the raw-counts matrix.
+        // Two regions: chr1=GGAA, chr2=GCGC → pooled: GG×1, GA×1, AA×1, GC×2, CG×1 = 6 total
+        let path = get_fasta_path("base.fa");
+        let ga = GenomeAssembly::try_from(path.to_str().unwrap()).unwrap();
+        let regions = vec![
+            Region { chr: "chr1".into(), start: 0, end: 4, rest: None },
+            Region { chr: "chr2".into(), start: 0, end: 4, rest: None },
+        ];
+        let rs = RegionSet::from(regions);
+        let (_, matrix) = calc_dinucl_freq(&rs, &ga, true).unwrap();
+
+        let mut totals = [0.0f64; 16];
+        for row in &matrix {
+            for (i, &c) in row.iter().enumerate() {
+                totals[i] += c;
+            }
+        }
+        let grand: f64 = totals.iter().sum();
+        assert_eq!(grand, 6.0);
     }
 
     // --- Empty RegionSet edge cases ---

--- a/gtars-python/py_src/gtars/genomic_distributions/__init__.pyi
+++ b/gtars-python/py_src/gtars/genomic_distributions/__init__.pyi
@@ -14,15 +14,31 @@ def calc_gc_content(
     """
     ...
 
-def calc_dinucleotide_frequency(
+def calc_dinucl_freq(
     rs: RegionSet, genome: GenomeAssembly
 ) -> Dict[str, int]:
     """
-    Calculate dinucleotide frequencies across all regions.
+    Global dinucleotide frequencies (one count per dinucleotide, pooled across all regions).
 
     :param rs: RegionSet object
     :param genome: GenomeAssembly object (reference genome)
-    :return: dict mapping dinucleotide names to counts
+    :return: dict mapping dinucleotide names (e.g. "Aa", "Cg") to total counts
+    """
+    ...
+
+def calc_dinucl_freq_per_region(
+    rs: RegionSet, genome: GenomeAssembly
+) -> Dict[str, object]:
+    """
+    Per-region dinucleotide frequencies as percentages (0–100).
+
+    :param rs: RegionSet object
+    :param genome: GenomeAssembly object (reference genome)
+    :return: dict with keys:
+        - ``region_labels``: list of ``chr_start_end`` strings (one per region)
+        - ``dinucleotides``: list of 16 dinucleotide names in canonical order
+        - ``frequencies``: list of lists — one row per region, 16 values per row
+          matching ``dinucleotides`` order
     """
     ...
 

--- a/gtars-python/py_src/gtars/genomic_distributions/__init__.pyi
+++ b/gtars-python/py_src/gtars/genomic_distributions/__init__.pyi
@@ -15,30 +15,23 @@ def calc_gc_content(
     ...
 
 def calc_dinucl_freq(
-    rs: RegionSet, genome: GenomeAssembly
-) -> Dict[str, int]:
-    """
-    Global dinucleotide frequencies (one count per dinucleotide, pooled across all regions).
-
-    :param rs: RegionSet object
-    :param genome: GenomeAssembly object (reference genome)
-    :return: dict mapping dinucleotide names (e.g. "Aa", "Cg") to total counts
-    """
-    ...
-
-def calc_dinucl_freq_per_region(
-    rs: RegionSet, genome: GenomeAssembly
+    rs: RegionSet, genome: GenomeAssembly, raw_counts: bool = False
 ) -> Dict[str, object]:
     """
-    Per-region dinucleotide frequencies as percentages (0–100).
+    Per-region dinucleotide frequencies, matching R GenomicDistributions ``calcDinuclFreq``.
 
     :param rs: RegionSet object
     :param genome: GenomeAssembly object (reference genome)
+    :param raw_counts: if False (default), return percentages (0–100) per row;
+        if True, return raw integer-valued counts
     :return: dict with keys:
         - ``region_labels``: list of ``chr_start_end`` strings (one per region)
         - ``dinucleotides``: list of 16 dinucleotide names in canonical order
         - ``frequencies``: list of lists — one row per region, 16 values per row
           matching ``dinucleotides`` order
+
+    For pooled global counts across all regions, sum each column of the
+    raw-counts matrix.
     """
     ...
 

--- a/gtars-python/py_src/gtars/models/__init__.pyi
+++ b/gtars-python/py_src/gtars/models/__init__.pyi
@@ -124,17 +124,22 @@ class RegionSet:
         """
         ...
 
-    def neighbor_distances(self) -> List[Optional[float]]:
+    def neighbor_distances(self) -> List[int]:
         """
-        Distances between consecutive regions on each chromosome.
-        Returns None for missing values.
+        Signed gaps between consecutive regions on each chromosome.
+
+        Output length may be shorter than input region count — chromosomes with
+        fewer than 2 regions are skipped (no neighbors to measure against).
+        Output is NOT aligned 1:1 with input regions.
         """
         ...
 
-    def nearest_neighbors(self) -> List[Optional[float]]:
+    def nearest_neighbors(self) -> List[int]:
         """
-        Distance from each region to its nearest neighbor.
-        Returns None for regions with no neighbor on the same chromosome.
+        Distance from each region to its nearest neighbor on the same chromosome.
+
+        Output length may be shorter than input region count — chromosomes with
+        only one region are skipped. Output is NOT aligned 1:1 with input regions.
         """
         ...
 

--- a/gtars-python/src/genomic_distributions/mod.rs
+++ b/gtars-python/src/genomic_distributions/mod.rs
@@ -2,16 +2,14 @@ use pyo3::prelude::*;
 
 mod tools;
 pub use self::tools::{
-    py_calc_dinucl_freq, py_calc_dinucl_freq_per_region, py_calc_expected_partitions,
-    py_calc_gc_content, py_calc_partitions, py_calc_summary_signal, py_consensus,
-    py_median_abs_distance,
+    py_calc_dinucl_freq, py_calc_expected_partitions, py_calc_gc_content, py_calc_partitions,
+    py_calc_summary_signal, py_consensus, py_median_abs_distance,
 };
 
 #[pymodule]
 pub fn genomic_distributions(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_calc_gc_content, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_dinucl_freq, m)?)?;
-    m.add_function(wrap_pyfunction!(py_calc_dinucl_freq_per_region, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_partitions, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_expected_partitions, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_summary_signal, m)?)?;

--- a/gtars-python/src/genomic_distributions/mod.rs
+++ b/gtars-python/src/genomic_distributions/mod.rs
@@ -2,14 +2,16 @@ use pyo3::prelude::*;
 
 mod tools;
 pub use self::tools::{
-    py_calc_dinucleotide_frequency, py_calc_expected_partitions, py_calc_gc_content,
-    py_calc_partitions, py_calc_summary_signal, py_consensus, py_median_abs_distance,
+    py_calc_dinucl_freq, py_calc_dinucl_freq_per_region, py_calc_expected_partitions,
+    py_calc_gc_content, py_calc_partitions, py_calc_summary_signal, py_consensus,
+    py_median_abs_distance,
 };
 
 #[pymodule]
 pub fn genomic_distributions(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_calc_gc_content, m)?)?;
-    m.add_function(wrap_pyfunction!(py_calc_dinucleotide_frequency, m)?)?;
+    m.add_function(wrap_pyfunction!(py_calc_dinucl_freq, m)?)?;
+    m.add_function(wrap_pyfunction!(py_calc_dinucl_freq_per_region, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_partitions, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_expected_partitions, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_summary_signal, m)?)?;

--- a/gtars-python/src/genomic_distributions/tools.rs
+++ b/gtars-python/src/genomic_distributions/tools.rs
@@ -20,34 +20,31 @@ pub fn py_calc_gc_content(
     Ok(result)
 }
 
-#[pyfunction(name = "calc_dinucl_freq")]
-pub fn py_calc_dinucl_freq(
-    rs: &PyRegionSet,
-    genome: &PyGenomeAssembly,
-) -> anyhow::Result<HashMap<String, u64>> {
-    let frequencies = statistics::calc_dinucl_freq(&rs.regionset, &genome.genome_assembly)?;
-    let mut freq_map: HashMap<String, u64> = HashMap::new();
-    for (di, freq) in frequencies {
-        freq_map.insert(di.to_string()?, freq);
-    }
-    Ok(freq_map)
-}
-
-/// Per-region dinucleotide frequencies as percentages (0–100).
+/// Per-region dinucleotide frequencies, matching R GenomicDistributions `calcDinuclFreq`.
 ///
-/// Returns a dict with:
+/// Arguments:
+///   - ``rs``: RegionSet
+///   - ``genome``: GenomeAssembly (reference)
+///   - ``raw_counts``: if False (default), return percentages (0–100) per row;
+///     if True, return raw integer-valued counts
+///
+/// Returns a dict:
 ///   - ``region_labels``: list of ``chr_start_end`` strings (one per region)
 ///   - ``dinucleotides``: list of 16 dinucleotide names in canonical order
 ///   - ``frequencies``: list of lists — one row per region, 16 values per row
 ///     matching ``dinucleotides`` order
-#[pyfunction(name = "calc_dinucl_freq_per_region")]
-pub fn py_calc_dinucl_freq_per_region<'py>(
+///
+/// For pooled global counts, sum each column of the raw-counts matrix.
+#[pyfunction(name = "calc_dinucl_freq")]
+#[pyo3(signature = (rs, genome, raw_counts = false))]
+pub fn py_calc_dinucl_freq<'py>(
     py: Python<'py>,
     rs: &PyRegionSet,
     genome: &PyGenomeAssembly,
+    raw_counts: bool,
 ) -> anyhow::Result<Bound<'py, PyDict>> {
     let (labels, matrix) =
-        statistics::calc_dinucl_freq_per_region(&rs.regionset, &genome.genome_assembly)?;
+        statistics::calc_dinucl_freq(&rs.regionset, &genome.genome_assembly, raw_counts)?;
     let dinucl_names: Vec<String> = statistics::DINUCL_ORDER
         .iter()
         .map(|d| d.to_string().unwrap_or_default())

--- a/gtars-python/src/genomic_distributions/tools.rs
+++ b/gtars-python/src/genomic_distributions/tools.rs
@@ -20,19 +20,44 @@ pub fn py_calc_gc_content(
     Ok(result)
 }
 
-#[pyfunction(name = "calc_dinucleotide_frequency")]
-pub fn py_calc_dinucleotide_frequency(
+#[pyfunction(name = "calc_dinucl_freq")]
+pub fn py_calc_dinucl_freq(
     rs: &PyRegionSet,
     genome: &PyGenomeAssembly,
 ) -> anyhow::Result<HashMap<String, u64>> {
     let frequencies = statistics::calc_dinucl_freq(&rs.regionset, &genome.genome_assembly)?;
     let mut freq_map: HashMap<String, u64> = HashMap::new();
-    // Convert Dinucleotide to String and push to HashMap
     for (di, freq) in frequencies {
         freq_map.insert(di.to_string()?, freq);
     }
-
     Ok(freq_map)
+}
+
+/// Per-region dinucleotide frequencies as percentages (0–100).
+///
+/// Returns a dict with:
+///   - ``region_labels``: list of ``chr_start_end`` strings (one per region)
+///   - ``dinucleotides``: list of 16 dinucleotide names in canonical order
+///   - ``frequencies``: list of lists — one row per region, 16 values per row
+///     matching ``dinucleotides`` order
+#[pyfunction(name = "calc_dinucl_freq_per_region")]
+pub fn py_calc_dinucl_freq_per_region<'py>(
+    py: Python<'py>,
+    rs: &PyRegionSet,
+    genome: &PyGenomeAssembly,
+) -> anyhow::Result<Bound<'py, PyDict>> {
+    let (labels, matrix) =
+        statistics::calc_dinucl_freq_per_region(&rs.regionset, &genome.genome_assembly)?;
+    let dinucl_names: Vec<String> = statistics::DINUCL_ORDER
+        .iter()
+        .map(|d| d.to_string().unwrap_or_default())
+        .collect();
+    let freqs_nested: Vec<Vec<f64>> = matrix.into_iter().map(|row| row.to_vec()).collect();
+    let result = PyDict::new(py);
+    result.set_item("region_labels", labels)?;
+    result.set_item("dinucleotides", dinucl_names)?;
+    result.set_item("frequencies", freqs_nested)?;
+    Ok(result)
 }
 
 #[pyfunction(name = "calc_partitions")]

--- a/gtars-python/src/models/region_set.rs
+++ b/gtars-python/src/models/region_set.rs
@@ -298,38 +298,25 @@ impl PyRegionSet {
         self.regionset.calc_widths()
     }
 
-    fn neighbor_distances(&self) -> PyResult<Vec<Option<f64>>> {
-        let dists = self
-            .regionset
+    /// Signed gaps between consecutive regions on each chromosome.
+    ///
+    /// Output length may be shorter than input region count — chromosomes with
+    /// fewer than 2 regions are skipped (no neighbors to measure against). Output
+    /// is not aligned 1:1 with input regions.
+    fn neighbor_distances(&self) -> PyResult<Vec<i64>> {
+        self.regionset
             .calc_neighbor_distances()
-            .map_err(|e| PyValueError::new_err(e.to_string()))?;
-        Ok(dists
-            .into_iter()
-            .map(|d| {
-                if d == i64::MAX {
-                    None
-                } else {
-                    Some(d as f64)
-                }
-            })
-            .collect())
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
-    fn nearest_neighbors(&self) -> PyResult<Vec<Option<f64>>> {
-        let dists = self
-            .regionset
+    /// Distance from each region to its nearest neighbor on the same chromosome.
+    ///
+    /// Output length may be shorter than input region count — chromosomes with
+    /// only one region are skipped. Output is not aligned 1:1 with input regions.
+    fn nearest_neighbors(&self) -> PyResult<Vec<u32>> {
+        self.regionset
             .calc_nearest_neighbors()
-            .map_err(|e| PyValueError::new_err(e.to_string()))?;
-        Ok(dists
-            .into_iter()
-            .map(|d| {
-                if d == u32::MAX {
-                    None
-                } else {
-                    Some(d as f64)
-                }
-            })
-            .collect())
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
     #[pyo3(signature = (n_bins = 250, chrom_sizes = None))]

--- a/gtars-python/tests/test_genomicdist.py
+++ b/gtars-python/tests/test_genomicdist.py
@@ -55,8 +55,18 @@ class TestRegionSetStatistics:
         )
         dists = rs.neighbor_distances()
         assert len(dists) == 2
-        assert dists[0] == 100.0  # 300 - 200
-        assert dists[1] == 100.0  # 500 - 400
+        assert dists[0] == 100  # 300 - 200
+        assert dists[1] == 100  # 500 - 400
+        # Return type is List[int] (no None/sentinel wrapping)
+        assert all(isinstance(d, int) for d in dists)
+
+    def test_nearest_neighbors_return_type(self):
+        # Confirm no None/Optional wrapping — the core function skips
+        # single-region chroms rather than emitting sentinels.
+        rs = make_regionset([("chr1", 0, 10), ("chr1", 20, 30)])
+        nn = rs.nearest_neighbors()
+        assert all(isinstance(d, int) for d in nn)
+        assert None not in nn
 
     def test_neighbor_distances_overlapping(self):
         rs = make_regionset([("chr1", 100, 300), ("chr1", 200, 400)])

--- a/gtars-r/R/extendr-wrappers.R
+++ b/gtars-r/R/extendr-wrappers.R
@@ -69,14 +69,23 @@ load_genome_assembly <- function(fasta_path) .Call(wrap__r_load_genome_assembly,
 #' @export
 #' @param rs_ptr External pointer to a RegionSet
 #' @param assembly_ptr External pointer to a GenomeAssembly
-#' @param ignore_unk_chroms Skip regions on chromosomes not in the assembly
+#' @param ignore_unk_chroms Skip regions on chromosomes not in the assembly.
+#'   Pass NULL (the default) or FALSE to error on unknown chromosomes.
 r_calc_gc_content <- function(rs_ptr, assembly_ptr, ignore_unk_chroms) .Call(wrap__r_calc_gc_content, rs_ptr, assembly_ptr, ignore_unk_chroms)
 
-#' Calculate per-region dinucleotide frequencies (percentages)
+#' Calculate per-region dinucleotide frequencies (matches R GenomicDistributions calcDinuclFreq)
+#'
+#' Returns a list with a ``region`` column and 16 dinucleotide columns
+#' (AA, AC, ..., TT). When ``raw_counts`` is FALSE (default), each row sums
+#' to 100 (percentages). When TRUE, values are raw integer counts.
+#'
+#' For pooled global counts, sum each dinucleotide column across rows
+#' (with ``raw_counts=TRUE``).
 #' @export
 #' @param rs_ptr External pointer to a RegionSet
 #' @param assembly_ptr External pointer to a GenomeAssembly
-r_calc_dinucl_freq <- function(rs_ptr, assembly_ptr) .Call(wrap__r_calc_dinucl_freq, rs_ptr, assembly_ptr)
+#' @param raw_counts Return raw counts instead of percentages (default FALSE, matches R upstream)
+r_calc_dinucl_freq <- function(rs_ptr, assembly_ptr, raw_counts) .Call(wrap__r_calc_dinucl_freq, rs_ptr, assembly_ptr, raw_counts)
 
 #' Trim regions to chromosome boundaries
 #' @export

--- a/gtars-r/R/genomicdist.R
+++ b/gtars-r/R/genomicdist.R
@@ -96,18 +96,21 @@ calcGCContent <- function(query, ref, ignoreUnkChroms = FALSE) {
 #' Calculate dinucleotide frequency
 #'
 #' @description Calculates the frequency of all 16 dinucleotides for each
-#'   region as percentages. Drop-in replacement for
-#'   GenomicDistributions::calcDinuclFreq.
+#'   region. Drop-in replacement for GenomicDistributions::calcDinuclFreq,
+#'   including the \code{rawCounts} parameter.
 #'
 #' @param query A GRanges object, file path, data.frame, or RegionSet
 #' @param ref A GenomeAssembly pointer (from loadGenomeAssembly)
+#' @param rawCounts If TRUE, return raw integer counts; if FALSE (default),
+#'   return percentages per row (each row sums to 100)
 #' @return A data.frame with a \code{region} column and 16 dinucleotide
-#'   columns containing frequency percentages.
+#'   columns. For pooled global counts, call \code{colSums(result[, -1])}
+#'   on a \code{rawCounts=TRUE} result.
 #'
 #' @export
-calcDinuclFreq <- function(query, ref) {
+calcDinuclFreq <- function(query, ref, rawCounts = FALSE) {
   query <- .ensure_regionset(query)
-  result <- .Call(wrap__r_calc_dinucl_freq, query, ref)
+  result <- .Call(wrap__r_calc_dinucl_freq, query, ref, rawCounts)
   as.data.frame(result, stringsAsFactors = FALSE)
 }
 

--- a/gtars-r/man/calcDinuclFreq.Rd
+++ b/gtars-r/man/calcDinuclFreq.Rd
@@ -4,19 +4,23 @@
 \alias{calcDinuclFreq}
 \title{Calculate dinucleotide frequency}
 \usage{
-calcDinuclFreq(query, ref)
+calcDinuclFreq(query, ref, rawCounts = FALSE)
 }
 \arguments{
 \item{query}{A GRanges object, file path, data.frame, or RegionSet}
 
 \item{ref}{A GenomeAssembly pointer (from loadGenomeAssembly)}
+
+\item{rawCounts}{If TRUE, return raw integer counts; if FALSE (default),
+return percentages per row (each row sums to 100)}
 }
 \value{
 A data.frame with a \code{region} column and 16 dinucleotide
-columns containing frequency percentages.
+columns. For pooled global counts, call \code{colSums(result[, -1])}
+on a \code{rawCounts=TRUE} result.
 }
 \description{
 Calculates the frequency of all 16 dinucleotides for each
-region as percentages. Drop-in replacement for
-GenomicDistributions::calcDinuclFreq.
+region. Drop-in replacement for GenomicDistributions::calcDinuclFreq,
+including the \code{rawCounts} parameter.
 }

--- a/gtars-r/man/r_calc_dinucl_freq.Rd
+++ b/gtars-r/man/r_calc_dinucl_freq.Rd
@@ -2,15 +2,23 @@
 % Please edit documentation in R/extendr-wrappers.R
 \name{r_calc_dinucl_freq}
 \alias{r_calc_dinucl_freq}
-\title{Calculate per-region dinucleotide frequencies (percentages)}
+\title{Calculate per-region dinucleotide frequencies (matches R GenomicDistributions calcDinuclFreq)}
 \usage{
-r_calc_dinucl_freq(rs_ptr, assembly_ptr)
+r_calc_dinucl_freq(rs_ptr, assembly_ptr, raw_counts)
 }
 \arguments{
 \item{rs_ptr}{External pointer to a RegionSet}
 
 \item{assembly_ptr}{External pointer to a GenomeAssembly}
+
+\item{raw_counts}{Return raw counts instead of percentages (default FALSE, matches R upstream)}
 }
 \description{
-Calculate per-region dinucleotide frequencies (percentages)
+Returns a list with a \code{region} column and 16 dinucleotide columns
+(AA, AC, ..., TT). When \code{raw_counts} is FALSE (default), each row sums
+to 100 (percentages). When TRUE, values are raw integer counts.
+}
+\details{
+For pooled global counts, sum each dinucleotide column across rows
+(with \code{raw_counts=TRUE}).
 }

--- a/gtars-r/man/r_calc_gc_content.Rd
+++ b/gtars-r/man/r_calc_gc_content.Rd
@@ -11,7 +11,8 @@ r_calc_gc_content(rs_ptr, assembly_ptr, ignore_unk_chroms)
 
 \item{assembly_ptr}{External pointer to a GenomeAssembly}
 
-\item{ignore_unk_chroms}{Skip regions on chromosomes not in the assembly}
+\item{ignore_unk_chroms}{Skip regions on chromosomes not in the assembly.
+Pass NULL (the default) or FALSE to error on unknown chromosomes.}
 }
 \description{
 Calculate GC content for each region

--- a/gtars-r/src/rust/src/genomicdist.rs
+++ b/gtars-r/src/rust/src/genomicdist.rs
@@ -6,7 +6,7 @@ use gtars_core::models::{Region, RegionSet, RegionSetList};
 use gtars_genomicdist::models::{GenomeAssembly, TssIndex};
 use gtars_overlaprs::RegionSetOverlaps;
 use gtars_genomicdist::{
-    calc_dinucl_freq, calc_dinucl_freq_per_region, calc_gc_content, calc_summary_signal,
+    calc_dinucl_freq, calc_gc_content, calc_summary_signal,
     chrom_karyotype_key, consensus, genome_partition_list, calc_expected_partitions,
     calc_partitions, pairwise_jaccard,
     CoordinateMode, GenomicDistAnnotation, GenomicIntervalSetStatistics, GeneModel, IntervalRanges,
@@ -315,55 +315,34 @@ pub fn r_calc_gc_content(
     })
 }
 
-/// Calculate global dinucleotide frequencies across all regions
+/// Calculate per-region dinucleotide frequencies (matches R GenomicDistributions calcDinuclFreq)
 ///
-/// Returns a named integer vector mapping each dinucleotide (AA, AC, ..., TT)
-/// to its total count across all regions in the RegionSet.
+/// Returns a list with a ``region`` column and 16 dinucleotide columns
+/// (AA, AC, ..., TT). When ``raw_counts`` is FALSE (default), each row sums
+/// to 100 (percentages). When TRUE, values are raw integer counts.
+///
+/// For pooled global counts, sum each dinucleotide column across rows
+/// (with ``raw_counts=TRUE``).
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 /// @param assembly_ptr External pointer to a GenomeAssembly
+/// @param raw_counts Return raw counts instead of percentages (default FALSE, matches R upstream)
 #[extendr(r_name = "r_calc_dinucl_freq")]
-pub fn r_calc_dinucl_freq_global(
+pub fn r_calc_dinucl_freq(
     rs_ptr: Robj,
     assembly_ptr: Robj,
+    raw_counts: Robj,
 ) -> extendr_api::Result<List> {
+    // Default to false when NULL/missing — matches Python and R GenomicDistributions defaults
+    let raw = if raw_counts.is_null() {
+        false
+    } else {
+        <bool>::try_from(&raw_counts)
+            .map_err(|_| extendr_api::Error::Other("raw_counts must be logical".into()))?
+    };
     with_regionset!(rs_ptr, rs, {
         with_assembly!(assembly_ptr, asm, {
-            let freqs = calc_dinucl_freq(rs, asm)
-                .map_err(|e| extendr_api::Error::Other(format!("{}", e)))?;
-            // Build ordered (name, count) pairs using canonical DINUCL_ORDER
-            let mut pairs: Vec<(&str, Robj)> = Vec::with_capacity(16);
-            let mut name_storage: Vec<String> = Vec::with_capacity(16);
-            for dn in DINUCL_ORDER.iter() {
-                let count = freqs.get(dn).copied().unwrap_or(0);
-                name_storage.push(
-                    dn.to_string()
-                        .unwrap_or_else(|_| "??".into())
-                        .to_uppercase(),
-                );
-                // count is u64 — push as f64 for R (no native u64)
-                pairs.push(("", Robj::from(count as f64)));
-            }
-            // Rebuild pairs with real names from name_storage
-            let pairs_named: Vec<(&str, Robj)> = name_storage
-                .iter()
-                .zip(pairs.into_iter())
-                .map(|(name, (_, robj))| (name.as_str(), robj))
-                .collect();
-            Ok(List::from_pairs(pairs_named))
-        })
-    })
-}
-
-/// Calculate per-region dinucleotide frequencies (percentages)
-/// @export
-/// @param rs_ptr External pointer to a RegionSet
-/// @param assembly_ptr External pointer to a GenomeAssembly
-#[extendr(r_name = "r_calc_dinucl_freq_per_region")]
-pub fn r_calc_dinucl_freq_per_region(rs_ptr: Robj, assembly_ptr: Robj) -> extendr_api::Result<List> {
-    with_regionset!(rs_ptr, rs, {
-        with_assembly!(assembly_ptr, asm, {
-            let (labels, matrix) = calc_dinucl_freq_per_region(rs, asm)
+            let (labels, matrix) = calc_dinucl_freq(rs, asm, raw)
                 .map_err(|e| extendr_api::Error::Other(format!("{}", e)))?;
 
             // Build column names (uppercase to match GD: AA, AC, AG, ...)
@@ -1305,8 +1284,7 @@ extendr_module! {
     // GC / Dinucleotide
     fn r_load_genome_assembly;
     fn r_calc_gc_content;
-    fn r_calc_dinucl_freq_global;
-    fn r_calc_dinucl_freq_per_region;
+    fn r_calc_dinucl_freq;
     // Interval Ranges
     fn r_trim;
     fn r_promoters;

--- a/gtars-r/src/rust/src/genomicdist.rs
+++ b/gtars-r/src/rust/src/genomicdist.rs
@@ -6,9 +6,9 @@ use gtars_core::models::{Region, RegionSet, RegionSetList};
 use gtars_genomicdist::models::{GenomeAssembly, TssIndex};
 use gtars_overlaprs::RegionSetOverlaps;
 use gtars_genomicdist::{
-    calc_dinucl_freq_per_region, calc_gc_content, calc_summary_signal, chrom_karyotype_key,
-    consensus, genome_partition_list, calc_expected_partitions, calc_partitions,
-    pairwise_jaccard,
+    calc_dinucl_freq, calc_dinucl_freq_per_region, calc_gc_content, calc_summary_signal,
+    chrom_karyotype_key, consensus, genome_partition_list, calc_expected_partitions,
+    calc_partitions, pairwise_jaccard,
     CoordinateMode, GenomicDistAnnotation, GenomicIntervalSetStatistics, GeneModel, IntervalRanges,
     PartitionList, SignalMatrix, Strand, StrandedRegionSet, DINUCL_ORDER,
 };
@@ -135,9 +135,11 @@ pub fn r_regionset_length(rs_ptr: Robj) -> extendr_api::Result<i32> {
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 #[extendr(r_name = "r_calc_widths")]
-pub fn r_calc_widths(rs_ptr: Robj) -> extendr_api::Result<Vec<i32>> {
+pub fn r_calc_widths(rs_ptr: Robj) -> extendr_api::Result<Vec<f64>> {
+    // f64 instead of i32: widths are u32 in Rust and can exceed i32::MAX (2.1 Gbp)
+    // for concatenated/genome-scale regions. f64 safely represents any u32.
     with_regionset!(rs_ptr, rs, {
-        Ok(rs.calc_widths().into_iter().map(|w| w as i32).collect())
+        Ok(rs.calc_widths().into_iter().map(|w| w as f64).collect())
     })
 }
 
@@ -158,12 +160,14 @@ pub fn r_calc_neighbor_distances(rs_ptr: Robj) -> extendr_api::Result<Vec<f64>> 
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 #[extendr(r_name = "r_calc_nearest_neighbors")]
-pub fn r_calc_nearest_neighbors(rs_ptr: Robj) -> extendr_api::Result<Vec<i32>> {
+pub fn r_calc_nearest_neighbors(rs_ptr: Robj) -> extendr_api::Result<Vec<f64>> {
+    // f64 instead of i32: neighbor distances are chromosome-scale (up to ~250M on
+    // hg38) and genome-concatenated BEDs could push past i32::MAX (2.1 Gbp).
     with_regionset!(rs_ptr, rs, {
         let dists = rs
             .calc_nearest_neighbors()
             .map_err(|e| extendr_api::Error::Other(format!("{}", e)))?;
-        Ok(dists.into_iter().map(|d| d as i32).collect())
+        Ok(dists.into_iter().map(|d| d as f64).collect())
     })
 }
 
@@ -180,21 +184,23 @@ pub fn r_chromosome_statistics(rs_ptr: Robj) -> extendr_api::Result<List> {
         });
 
         let mut chr_names: Vec<String> = Vec::new();
-        let mut n_regions: Vec<i32> = Vec::new();
+        let mut n_regions: Vec<f64> = Vec::new();
         let mut start_pos: Vec<f64> = Vec::new();
         let mut end_pos: Vec<f64> = Vec::new();
-        let mut min_len: Vec<i32> = Vec::new();
-        let mut max_len: Vec<i32> = Vec::new();
+        let mut min_len: Vec<f64> = Vec::new();
+        let mut max_len: Vec<f64> = Vec::new();
         let mut mean_len: Vec<f64> = Vec::new();
         let mut median_len: Vec<f64> = Vec::new();
 
+        // f64 for count and length fields: u32 values can exceed i32::MAX (2.1 Gbp)
+        // for wide regions, and region_count has no upper bound.
         for (chr, s) in &entries {
             chr_names.push(chr.clone());
-            n_regions.push(s.number_of_regions as i32);
+            n_regions.push(s.number_of_regions as f64);
             start_pos.push(s.start_nucleotide_position as f64);
             end_pos.push(s.end_nucleotide_position as f64);
-            min_len.push(s.minimum_region_length as i32);
-            max_len.push(s.maximum_region_length as i32);
+            min_len.push(s.minimum_region_length as f64);
+            max_len.push(s.maximum_region_length as f64);
             mean_len.push(s.mean_region_length);
             median_len.push(s.median_region_length);
         }
@@ -286,17 +292,65 @@ pub fn r_load_genome_assembly(fasta_path: &str) -> extendr_api::Result<Robj> {
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 /// @param assembly_ptr External pointer to a GenomeAssembly
-/// @param ignore_unk_chroms Skip regions on chromosomes not in the assembly
+/// @param ignore_unk_chroms Skip regions on chromosomes not in the assembly.
+///   Pass NULL (the default) or FALSE to error on unknown chromosomes.
 #[extendr(r_name = "r_calc_gc_content")]
 pub fn r_calc_gc_content(
     rs_ptr: Robj,
     assembly_ptr: Robj,
-    ignore_unk_chroms: bool,
+    ignore_unk_chroms: Robj,
 ) -> extendr_api::Result<Vec<f64>> {
+    // Default to false when NULL/missing — matches Python's default
+    let ignore = if ignore_unk_chroms.is_null() {
+        false
+    } else {
+        <bool>::try_from(&ignore_unk_chroms)
+            .map_err(|_| extendr_api::Error::Other("ignore_unk_chroms must be logical".into()))?
+    };
     with_regionset!(rs_ptr, rs, {
         with_assembly!(assembly_ptr, asm, {
-            calc_gc_content(rs, asm, ignore_unk_chroms)
+            calc_gc_content(rs, asm, ignore)
                 .map_err(|e| extendr_api::Error::Other(format!("{}", e)))
+        })
+    })
+}
+
+/// Calculate global dinucleotide frequencies across all regions
+///
+/// Returns a named integer vector mapping each dinucleotide (AA, AC, ..., TT)
+/// to its total count across all regions in the RegionSet.
+/// @export
+/// @param rs_ptr External pointer to a RegionSet
+/// @param assembly_ptr External pointer to a GenomeAssembly
+#[extendr(r_name = "r_calc_dinucl_freq")]
+pub fn r_calc_dinucl_freq_global(
+    rs_ptr: Robj,
+    assembly_ptr: Robj,
+) -> extendr_api::Result<List> {
+    with_regionset!(rs_ptr, rs, {
+        with_assembly!(assembly_ptr, asm, {
+            let freqs = calc_dinucl_freq(rs, asm)
+                .map_err(|e| extendr_api::Error::Other(format!("{}", e)))?;
+            // Build ordered (name, count) pairs using canonical DINUCL_ORDER
+            let mut pairs: Vec<(&str, Robj)> = Vec::with_capacity(16);
+            let mut name_storage: Vec<String> = Vec::with_capacity(16);
+            for dn in DINUCL_ORDER.iter() {
+                let count = freqs.get(dn).copied().unwrap_or(0);
+                name_storage.push(
+                    dn.to_string()
+                        .unwrap_or_else(|_| "??".into())
+                        .to_uppercase(),
+                );
+                // count is u64 — push as f64 for R (no native u64)
+                pairs.push(("", Robj::from(count as f64)));
+            }
+            // Rebuild pairs with real names from name_storage
+            let pairs_named: Vec<(&str, Robj)> = name_storage
+                .iter()
+                .zip(pairs.into_iter())
+                .map(|(name, (_, robj))| (name.as_str(), robj))
+                .collect();
+            Ok(List::from_pairs(pairs_named))
         })
     })
 }
@@ -305,8 +359,8 @@ pub fn r_calc_gc_content(
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 /// @param assembly_ptr External pointer to a GenomeAssembly
-#[extendr(r_name = "r_calc_dinucl_freq")]
-pub fn r_calc_dinucl_freq(rs_ptr: Robj, assembly_ptr: Robj) -> extendr_api::Result<List> {
+#[extendr(r_name = "r_calc_dinucl_freq_per_region")]
+pub fn r_calc_dinucl_freq_per_region(rs_ptr: Robj, assembly_ptr: Robj) -> extendr_api::Result<List> {
     with_regionset!(rs_ptr, rs, {
         with_assembly!(assembly_ptr, asm, {
             let (labels, matrix) = calc_dinucl_freq_per_region(rs, asm)
@@ -1251,7 +1305,8 @@ extendr_module! {
     // GC / Dinucleotide
     fn r_load_genome_assembly;
     fn r_calc_gc_content;
-    fn r_calc_dinucl_freq;
+    fn r_calc_dinucl_freq_global;
+    fn r_calc_dinucl_freq_per_region;
     // Interval Ranges
     fn r_trim;
     fn r_promoters;

--- a/gtars-r/tests/testthat/test_genomicdist.R
+++ b/gtars-r/tests/testthat/test_genomicdist.R
@@ -18,9 +18,10 @@ test_that("calcWidth returns correct widths", {
   skip_if_no_data()
   rs <- RegionSet(file.path(data_dir, "dummy.bed"))
   w <- calcWidth(rs)
-  expect_type(w, "integer")
+  # doubles instead of integers: u32 widths can exceed i32::MAX (2.1 Gbp)
+  expect_type(w, "double")
   expect_equal(length(w), 4L)
-  expect_equal(w[1], 4L)
+  expect_equal(w[1], 4)
 })
 
 test_that("calcNeighborDist returns distances", {
@@ -34,7 +35,9 @@ test_that("calcNearestNeighbors returns distances", {
   skip_if_no_data()
   rs <- RegionSet(file.path(data_dir, "dummy.bed"))
   nn <- calcNearestNeighbors(rs)
-  expect_type(nn, "integer")
+  # doubles instead of integers: distances can be chromosome-scale,
+  # approaching or exceeding i32::MAX for concatenated/genome-scale regions
+  expect_type(nn, "double")
   expect_equal(length(nn), length(rs))
 })
 
@@ -77,6 +80,23 @@ test_that("calcDinuclFreq returns data.frame with 16 dinucleotide columns", {
   expect_true(is.data.frame(freq))
   # 16 dinucleotides + region column
   expect_true(ncol(freq) >= 16)
+  # Default rawCounts=FALSE: each row sums to 100
+  num_cols <- freq[, sapply(freq, is.numeric)]
+  expect_equal(sum(num_cols[1, ]), 100, tolerance = 1e-6)
+})
+
+test_that("calcDinuclFreq rawCounts=TRUE returns integer counts", {
+  fasta_path <- file.path(test_path(), "..", "..", "..", "tests", "data", "fasta", "base.fa")
+  skip_if_not(file.exists(fasta_path), "Test FASTA file not found")
+
+  assembly <- loadGenomeAssembly(fasta_path)
+  # base.fa: chrX = "TTGGGGAA" (8bp) → 7 dinucleotide windows
+  df <- data.frame(chr = "chrX", start = 0L, end = 8L)
+  freq <- calcDinuclFreq(df, assembly, rawCounts = TRUE)
+  expect_true(is.data.frame(freq))
+  num_cols <- freq[, sapply(freq, is.numeric)]
+  # 8 bases → 7 dinucleotides
+  expect_equal(sum(num_cols[1, ]), 7)
 })
 
 # =========================================================================

--- a/gtars-r/tests/testthat/test_regionset.R
+++ b/gtars-r/tests/testthat/test_regionset.R
@@ -82,9 +82,10 @@ test_that("widths returns correct values", {
   # dummy.bed: chr1:2-6, chr1:4-7, chr1:5-9, chr1:7-12
   rs <- RegionSet(file.path(data_dir, "dummy.bed"))
   w <- widths(rs)
-  expect_type(w, "integer")
+  # doubles instead of integers: u32 widths can exceed i32::MAX (2.1 Gbp)
+  expect_type(w, "double")
   expect_equal(length(w), 4L)
-  expect_equal(w[1], 4L)
+  expect_equal(w[1], 4)
 })
 
 test_that("neighborDistances returns numeric vector", {
@@ -98,7 +99,8 @@ test_that("nearestNeighbors returns numeric vector", {
   skip_if_no_data()
   rs <- RegionSet(file.path(data_dir, "dummy.bed"))
   nn <- nearestNeighbors(rs)
-  expect_type(nn, "integer")
+  # doubles instead of integers: distances can be chromosome-scale
+  expect_type(nn, "double")
 })
 
 test_that("chromosomeStatistics returns data.frame", {


### PR DESCRIPTION
## Summary

Five related binding-alignment fixes, bundled into one PR as the finalization of the audit started with #248.

### 1. Remove dead `Option<>` wrapping (Python neighbor/nearest_neighbors)

Python's `neighbor_distances()` and `nearest_neighbors()` wrapped results in `Vec<Option<f64>>` with sentinel checks for `i64::MAX`/`u32::MAX` that the core functions never emit — dead defensive code. Now returns `List[int]` directly. Expanded genomicdist trait docstrings to document skip-single-region-chromosomes behavior.

### 2. Expose `calc_gc_content` in CLI

- `--fasta <PATH>` flag on `gtars genomicdist`
- `--ignore-unk-chroms` flag (default: `false`, matches Python)
- Output JSON gains `gc_content: {mean, per_region}` field

### 3. Fold `calc_dinucl_freq` variants into one R-aligned function

R GenomicDistributions only has a per-region `calcDinuclFreq` with a `rawCounts` parameter. gtars had inherited a "global" variant from gdrs (predecessor) that R upstream never had, plus a separate `_per_region` variant added later.

**Folded into single signature** matching R:
```rust
calc_dinucl_freq(rs, assembly, raw_counts: bool) -> (labels, matrix)
```
- `raw_counts=false` (default): per-region percentages (rows sum to 100)
- `raw_counts=true`: per-region raw integer counts
- For pooled global counts: sum each column of the raw-counts matrix

CLI: `--dinucl-raw-counts` flag; single `dinucl_freq` output field.
Python: `calc_dinucl_freq(rs, genome, raw_counts=False)`.
R: `r_calc_dinucl_freq` + user wrapper `calcDinuclFreq(query, ref, rawCounts=FALSE)` — drop-in match for R GenomicDistributions.

### 4. R binding `ignore_unk_chroms` default standardization

R binding's `r_calc_gc_content` previously required the `ignore_unk_chroms` bool. Now accepts `NULL` and defaults to `false`, matching Python.

### 5. R binding type cast overflow fix

Changed `u32 → i32` to `u32 → f64` for coordinate/width/count values. `u32` widths can exceed `i32::MAX` (2.1 Gbp) for concatenated/genome-scale regions. Return types change from integer to double vectors for:
- `r_calc_widths`
- `r_calc_nearest_neighbors`
- `r_chromosome_statistics` (number_of_regions, minimum_region_length, maximum_region_length)

## Deferred

WASM bindings for `calc_gc_content`/`calc_dinucl_freq` skipped — requires `GenomeAssembly` wrapper + client-side FASTA loading (multi-GB), impractical for browser.

## Test results

| Suite | Result |
|---|---|
| `cargo test -p gtars-genomicdist` | 262 passed (260 original + 2 new) |
| `pytest tests/` (gtars-python) | 147 passed (+1 new regression test) |
| `devtools::test()` (gtars-r) | all passing (+1 new rawCounts test, +3 type-cast updates) |
| CLI smoke (hg38 FASTA) | ✓ GC mean 0.659, dinucl percentages sum to 100, raw_counts=true sum = 399 for 400bp region |

## Breaking changes

- **Python**: `List[Optional[float]]` → `List[int]` for neighbor distances
- **Python**: `calc_dinucleotide_frequency` removed; `calc_dinucl_freq` now returns per-region dict (was: global `HashMap<String, u64>`)
- **R**: `calcDinuclFreq` gains a `rawCounts` parameter (backward-compat since it defaults to FALSE)
- **R**: `r_calc_widths`, `r_calc_nearest_neighbors`, `r_chromosome_statistics` return doubles instead of integers
- **R**: `r_calc_dinucl_freq` signature changed (now takes `raw_counts` Robj). User-facing `calcDinuclFreq` wrapper preserves the R GenomicDistributions API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)