### PR TITLE
Align calc_gc_content, calc_dinucl_freq, and R type casts across bindings

### DIFF
--- a/gtars-cli/src/genomicdist/cli.rs
+++ b/gtars-cli/src/genomicdist/cli.rs
@@ -44,6 +44,18 @@ pub fn create_genomicdist_cli() -> Command {
                 .help("Path to open signal matrix TSV (enables cell-type open chromatin enrichment)"),
         )
         .arg(
+            Arg::new("fasta")
+                .long("fasta")
+                .required(false)
+                .help("Path to genome FASTA file (enables GC content + dinucleotide frequencies)"),
+        )
+        .arg(
+            Arg::new("ignore-unk-chroms")
+                .long("ignore-unk-chroms")
+                .action(clap::ArgAction::SetTrue)
+                .help("When computing GC content, skip regions on chromosomes not in the FASTA (default: error)"),
+        )
+        .arg(
             Arg::new("promoter-upstream")
                 .long("promoter-upstream")
                 .required(false)

--- a/gtars-cli/src/genomicdist/handlers.rs
+++ b/gtars-cli/src/genomicdist/handlers.rs
@@ -9,12 +9,13 @@ use serde::Serialize;
 
 use gtars_core::models::{Region, RegionSet};
 use gtars_core::utils::get_chrom_sizes;
-use gtars_genomicdist::models::{ChromosomeStatistics, RegionBin, Strand, TssIndex};
+use gtars_genomicdist::models::{ChromosomeStatistics, GenomeAssembly, RegionBin, Strand, TssIndex};
 use gtars_genomicdist::statistics::GenomicIntervalSetStatistics;
 use gtars_genomicdist::{
     GeneModel, GenomicDistAnnotation, ExpectedPartitionResult, PartitionResult,
     calc_expected_partitions, calc_partitions, genome_partition_list,
     SignalMatrix, calc_summary_signal, ConditionStats,
+    calc_gc_content, calc_dinucl_freq, calc_dinucl_freq_per_region, DINUCL_ORDER,
     median_abs_distance,
 };
 
@@ -28,6 +29,30 @@ struct GenomicDistOutput {
     expected_partitions: Option<ExpectedPartitionResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     open_signal: Option<OpenSignalOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gc_content: Option<GcContentOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dinucl_freq: Option<HashMap<String, u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dinucl_freq_per_region: Option<DinuclFreqPerRegionOutput>,
+}
+
+#[derive(Serialize)]
+struct GcContentOutput {
+    /// Mean GC content across all regions (0–1)
+    mean: f64,
+    /// Per-region GC content values (0–1), one per region in input order
+    per_region: Vec<f64>,
+}
+
+#[derive(Serialize)]
+struct DinuclFreqPerRegionOutput {
+    /// Dinucleotide names in canonical order (matches DINUCL_ORDER)
+    dinucleotides: Vec<String>,
+    /// `chr_start_end` label per region
+    region_labels: Vec<String>,
+    /// Frequency matrix: outer is regions, inner is percentages per dinucleotide
+    frequencies: Vec<[f64; 16]>,
 }
 
 #[derive(Serialize)]
@@ -65,6 +90,8 @@ pub fn run_genomicdist(matches: &ArgMatches) -> Result<()> {
     let chrom_sizes_path = matches.get_one::<String>("chrom-sizes");
     let output_path = matches.get_one::<String>("output");
     let signal_matrix_path = matches.get_one::<String>("signal-matrix");
+    let fasta_path = matches.get_one::<String>("fasta");
+    let ignore_unk_chroms = matches.get_flag("ignore-unk-chroms");
     let n_bins: u32 = matches
         .get_one::<String>("bins")
         .unwrap()
@@ -229,6 +256,47 @@ pub fn run_genomicdist(matches: &ArgMatches) -> Result<()> {
         None => None,
     };
 
+    // --- Optional: GC content + dinucleotide frequencies (require FASTA) ---
+    let (gc_content_out, dinucl_freq_out, dinucl_per_region_out) = match fasta_path {
+        Some(p) => {
+            let assembly = GenomeAssembly::try_from(p.as_str())
+                .map_err(|e| anyhow::anyhow!("Failed to load FASTA: {}", e))?;
+            let gc_per_region = calc_gc_content(&rs, &assembly, ignore_unk_chroms)
+                .map_err(|e| anyhow::anyhow!("Failed to compute GC content: {}", e))?;
+            let gc_mean = if gc_per_region.is_empty() {
+                0.0
+            } else {
+                gc_per_region.iter().sum::<f64>() / gc_per_region.len() as f64
+            };
+            let gc_out = GcContentOutput {
+                mean: gc_mean,
+                per_region: gc_per_region,
+            };
+
+            let dinucl_global = calc_dinucl_freq(&rs, &assembly)
+                .map_err(|e| anyhow::anyhow!("Failed to compute dinucl freq: {}", e))?;
+            // Convert Dinucleotide keys to strings, ordered canonically
+            let mut dinucl_global_map: HashMap<String, u64> = HashMap::new();
+            for dn in DINUCL_ORDER.iter() {
+                let count = dinucl_global.get(dn).copied().unwrap_or(0);
+                dinucl_global_map.insert(dn.to_string().unwrap_or_default(), count);
+            }
+
+            let (labels, matrix) = calc_dinucl_freq_per_region(&rs, &assembly)
+                .map_err(|e| anyhow::anyhow!("Failed to compute dinucl freq per region: {}", e))?;
+            let per_region = DinuclFreqPerRegionOutput {
+                dinucleotides: DINUCL_ORDER
+                    .iter()
+                    .map(|d| d.to_string().unwrap_or_default())
+                    .collect(),
+                region_labels: labels,
+                frequencies: matrix,
+            };
+            (Some(gc_out), Some(dinucl_global_map), Some(per_region))
+        }
+        None => (None, None, None),
+    };
+
     // --- Build output ---
     let output = GenomicDistOutput {
         scalars: Scalars {
@@ -247,6 +315,9 @@ pub fn run_genomicdist(matches: &ArgMatches) -> Result<()> {
         },
         expected_partitions,
         open_signal,
+        gc_content: gc_content_out,
+        dinucl_freq: dinucl_freq_out,
+        dinucl_freq_per_region: dinucl_per_region_out,
     };
 
     let compact = matches.get_flag("compact");

--- a/gtars-python/py_src/gtars/genomic_distributions/__init__.pyi
+++ b/gtars-python/py_src/gtars/genomic_distributions/__init__.pyi
@@ -14,15 +14,31 @@ def calc_gc_content(
     """
     ...
 
-def calc_dinucleotide_frequency(
+def calc_dinucl_freq(
     rs: RegionSet, genome: GenomeAssembly
 ) -> Dict[str, int]:
     """
-    Calculate dinucleotide frequencies across all regions.
+    Global dinucleotide frequencies (one count per dinucleotide, pooled across all regions).
 
     :param rs: RegionSet object
     :param genome: GenomeAssembly object (reference genome)
-    :return: dict mapping dinucleotide names to counts
+    :return: dict mapping dinucleotide names (e.g. "Aa", "Cg") to total counts
+    """
+    ...
+
+def calc_dinucl_freq_per_region(
+    rs: RegionSet, genome: GenomeAssembly
+) -> Dict[str, object]:
+    """
+    Per-region dinucleotide frequencies as percentages (0–100).
+
+    :param rs: RegionSet object
+    :param genome: GenomeAssembly object (reference genome)
+    :return: dict with keys:
+        - ``region_labels``: list of ``chr_start_end`` strings (one per region)
+        - ``dinucleotides``: list of 16 dinucleotide names in canonical order
+        - ``frequencies``: list of lists — one row per region, 16 values per row
+          matching ``dinucleotides`` order
     """
     ...
 

--- a/gtars-python/src/genomic_distributions/mod.rs
+++ b/gtars-python/src/genomic_distributions/mod.rs
@@ -2,14 +2,16 @@ use pyo3::prelude::*;
 
 mod tools;
 pub use self::tools::{
-    py_calc_dinucleotide_frequency, py_calc_expected_partitions, py_calc_gc_content,
-    py_calc_partitions, py_calc_summary_signal, py_consensus, py_median_abs_distance,
+    py_calc_dinucl_freq, py_calc_dinucl_freq_per_region, py_calc_expected_partitions,
+    py_calc_gc_content, py_calc_partitions, py_calc_summary_signal, py_consensus,
+    py_median_abs_distance,
 };
 
 #[pymodule]
 pub fn genomic_distributions(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_calc_gc_content, m)?)?;
-    m.add_function(wrap_pyfunction!(py_calc_dinucleotide_frequency, m)?)?;
+    m.add_function(wrap_pyfunction!(py_calc_dinucl_freq, m)?)?;
+    m.add_function(wrap_pyfunction!(py_calc_dinucl_freq_per_region, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_partitions, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_expected_partitions, m)?)?;
     m.add_function(wrap_pyfunction!(py_calc_summary_signal, m)?)?;

--- a/gtars-python/src/genomic_distributions/tools.rs
+++ b/gtars-python/src/genomic_distributions/tools.rs
@@ -20,19 +20,44 @@ pub fn py_calc_gc_content(
     Ok(result)
 }
 
-#[pyfunction(name = "calc_dinucleotide_frequency")]
-pub fn py_calc_dinucleotide_frequency(
+#[pyfunction(name = "calc_dinucl_freq")]
+pub fn py_calc_dinucl_freq(
     rs: &PyRegionSet,
     genome: &PyGenomeAssembly,
 ) -> anyhow::Result<HashMap<String, u64>> {
     let frequencies = statistics::calc_dinucl_freq(&rs.regionset, &genome.genome_assembly)?;
     let mut freq_map: HashMap<String, u64> = HashMap::new();
-    // Convert Dinucleotide to String and push to HashMap
     for (di, freq) in frequencies {
         freq_map.insert(di.to_string()?, freq);
     }
-
     Ok(freq_map)
+}
+
+/// Per-region dinucleotide frequencies as percentages (0–100).
+///
+/// Returns a dict with:
+///   - ``region_labels``: list of ``chr_start_end`` strings (one per region)
+///   - ``dinucleotides``: list of 16 dinucleotide names in canonical order
+///   - ``frequencies``: list of lists — one row per region, 16 values per row
+///     matching ``dinucleotides`` order
+#[pyfunction(name = "calc_dinucl_freq_per_region")]
+pub fn py_calc_dinucl_freq_per_region<'py>(
+    py: Python<'py>,
+    rs: &PyRegionSet,
+    genome: &PyGenomeAssembly,
+) -> anyhow::Result<Bound<'py, PyDict>> {
+    let (labels, matrix) =
+        statistics::calc_dinucl_freq_per_region(&rs.regionset, &genome.genome_assembly)?;
+    let dinucl_names: Vec<String> = statistics::DINUCL_ORDER
+        .iter()
+        .map(|d| d.to_string().unwrap_or_default())
+        .collect();
+    let freqs_nested: Vec<Vec<f64>> = matrix.into_iter().map(|row| row.to_vec()).collect();
+    let result = PyDict::new(py);
+    result.set_item("region_labels", labels)?;
+    result.set_item("dinucleotides", dinucl_names)?;
+    result.set_item("frequencies", freqs_nested)?;
+    Ok(result)
 }
 
 #[pyfunction(name = "calc_partitions")]

--- a/gtars-r/src/rust/src/genomicdist.rs
+++ b/gtars-r/src/rust/src/genomicdist.rs
@@ -6,9 +6,9 @@ use gtars_core::models::{Region, RegionSet, RegionSetList};
 use gtars_genomicdist::models::{GenomeAssembly, TssIndex};
 use gtars_overlaprs::RegionSetOverlaps;
 use gtars_genomicdist::{
-    calc_dinucl_freq_per_region, calc_gc_content, calc_summary_signal, chrom_karyotype_key,
-    consensus, genome_partition_list, calc_expected_partitions, calc_partitions,
-    pairwise_jaccard,
+    calc_dinucl_freq, calc_dinucl_freq_per_region, calc_gc_content, calc_summary_signal,
+    chrom_karyotype_key, consensus, genome_partition_list, calc_expected_partitions,
+    calc_partitions, pairwise_jaccard,
     CoordinateMode, GenomicDistAnnotation, GenomicIntervalSetStatistics, GeneModel, IntervalRanges,
     PartitionList, SignalMatrix, Strand, StrandedRegionSet, DINUCL_ORDER,
 };
@@ -135,9 +135,11 @@ pub fn r_regionset_length(rs_ptr: Robj) -> extendr_api::Result<i32> {
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 #[extendr(r_name = "r_calc_widths")]
-pub fn r_calc_widths(rs_ptr: Robj) -> extendr_api::Result<Vec<i32>> {
+pub fn r_calc_widths(rs_ptr: Robj) -> extendr_api::Result<Vec<f64>> {
+    // f64 instead of i32: widths are u32 in Rust and can exceed i32::MAX (2.1 Gbp)
+    // for concatenated/genome-scale regions. f64 safely represents any u32.
     with_regionset!(rs_ptr, rs, {
-        Ok(rs.calc_widths().into_iter().map(|w| w as i32).collect())
+        Ok(rs.calc_widths().into_iter().map(|w| w as f64).collect())
     })
 }
 
@@ -158,12 +160,14 @@ pub fn r_calc_neighbor_distances(rs_ptr: Robj) -> extendr_api::Result<Vec<f64>> 
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 #[extendr(r_name = "r_calc_nearest_neighbors")]
-pub fn r_calc_nearest_neighbors(rs_ptr: Robj) -> extendr_api::Result<Vec<i32>> {
+pub fn r_calc_nearest_neighbors(rs_ptr: Robj) -> extendr_api::Result<Vec<f64>> {
+    // f64 instead of i32: neighbor distances are chromosome-scale (up to ~250M on
+    // hg38) and genome-concatenated BEDs could push past i32::MAX (2.1 Gbp).
     with_regionset!(rs_ptr, rs, {
         let dists = rs
             .calc_nearest_neighbors()
             .map_err(|e| extendr_api::Error::Other(format!("{}", e)))?;
-        Ok(dists.into_iter().map(|d| d as i32).collect())
+        Ok(dists.into_iter().map(|d| d as f64).collect())
     })
 }
 
@@ -180,21 +184,23 @@ pub fn r_chromosome_statistics(rs_ptr: Robj) -> extendr_api::Result<List> {
         });
 
         let mut chr_names: Vec<String> = Vec::new();
-        let mut n_regions: Vec<i32> = Vec::new();
+        let mut n_regions: Vec<f64> = Vec::new();
         let mut start_pos: Vec<f64> = Vec::new();
         let mut end_pos: Vec<f64> = Vec::new();
-        let mut min_len: Vec<i32> = Vec::new();
-        let mut max_len: Vec<i32> = Vec::new();
+        let mut min_len: Vec<f64> = Vec::new();
+        let mut max_len: Vec<f64> = Vec::new();
         let mut mean_len: Vec<f64> = Vec::new();
         let mut median_len: Vec<f64> = Vec::new();
 
+        // f64 for count and length fields: u32 values can exceed i32::MAX (2.1 Gbp)
+        // for wide regions, and region_count has no upper bound.
         for (chr, s) in &entries {
             chr_names.push(chr.clone());
-            n_regions.push(s.number_of_regions as i32);
+            n_regions.push(s.number_of_regions as f64);
             start_pos.push(s.start_nucleotide_position as f64);
             end_pos.push(s.end_nucleotide_position as f64);
-            min_len.push(s.minimum_region_length as i32);
-            max_len.push(s.maximum_region_length as i32);
+            min_len.push(s.minimum_region_length as f64);
+            max_len.push(s.maximum_region_length as f64);
             mean_len.push(s.mean_region_length);
             median_len.push(s.median_region_length);
         }
@@ -286,17 +292,65 @@ pub fn r_load_genome_assembly(fasta_path: &str) -> extendr_api::Result<Robj> {
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 /// @param assembly_ptr External pointer to a GenomeAssembly
-/// @param ignore_unk_chroms Skip regions on chromosomes not in the assembly
+/// @param ignore_unk_chroms Skip regions on chromosomes not in the assembly.
+///   Pass NULL (the default) or FALSE to error on unknown chromosomes.
 #[extendr(r_name = "r_calc_gc_content")]
 pub fn r_calc_gc_content(
     rs_ptr: Robj,
     assembly_ptr: Robj,
-    ignore_unk_chroms: bool,
+    ignore_unk_chroms: Robj,
 ) -> extendr_api::Result<Vec<f64>> {
+    // Default to false when NULL/missing — matches Python's default
+    let ignore = if ignore_unk_chroms.is_null() {
+        false
+    } else {
+        <bool>::try_from(&ignore_unk_chroms)
+            .map_err(|_| extendr_api::Error::Other("ignore_unk_chroms must be logical".into()))?
+    };
     with_regionset!(rs_ptr, rs, {
         with_assembly!(assembly_ptr, asm, {
-            calc_gc_content(rs, asm, ignore_unk_chroms)
+            calc_gc_content(rs, asm, ignore)
                 .map_err(|e| extendr_api::Error::Other(format!("{}", e)))
+        })
+    })
+}
+
+/// Calculate global dinucleotide frequencies across all regions
+///
+/// Returns a named integer vector mapping each dinucleotide (AA, AC, ..., TT)
+/// to its total count across all regions in the RegionSet.
+/// @export
+/// @param rs_ptr External pointer to a RegionSet
+/// @param assembly_ptr External pointer to a GenomeAssembly
+#[extendr(r_name = "r_calc_dinucl_freq")]
+pub fn r_calc_dinucl_freq_global(
+    rs_ptr: Robj,
+    assembly_ptr: Robj,
+) -> extendr_api::Result<List> {
+    with_regionset!(rs_ptr, rs, {
+        with_assembly!(assembly_ptr, asm, {
+            let freqs = calc_dinucl_freq(rs, asm)
+                .map_err(|e| extendr_api::Error::Other(format!("{}", e)))?;
+            // Build ordered (name, count) pairs using canonical DINUCL_ORDER
+            let mut pairs: Vec<(&str, Robj)> = Vec::with_capacity(16);
+            let mut name_storage: Vec<String> = Vec::with_capacity(16);
+            for dn in DINUCL_ORDER.iter() {
+                let count = freqs.get(dn).copied().unwrap_or(0);
+                name_storage.push(
+                    dn.to_string()
+                        .unwrap_or_else(|_| "??".into())
+                        .to_uppercase(),
+                );
+                // count is u64 — push as f64 for R (no native u64)
+                pairs.push(("", Robj::from(count as f64)));
+            }
+            // Rebuild pairs with real names from name_storage
+            let pairs_named: Vec<(&str, Robj)> = name_storage
+                .iter()
+                .zip(pairs.into_iter())
+                .map(|(name, (_, robj))| (name.as_str(), robj))
+                .collect();
+            Ok(List::from_pairs(pairs_named))
         })
     })
 }
@@ -305,8 +359,8 @@ pub fn r_calc_gc_content(
 /// @export
 /// @param rs_ptr External pointer to a RegionSet
 /// @param assembly_ptr External pointer to a GenomeAssembly
-#[extendr(r_name = "r_calc_dinucl_freq")]
-pub fn r_calc_dinucl_freq(rs_ptr: Robj, assembly_ptr: Robj) -> extendr_api::Result<List> {
+#[extendr(r_name = "r_calc_dinucl_freq_per_region")]
+pub fn r_calc_dinucl_freq_per_region(rs_ptr: Robj, assembly_ptr: Robj) -> extendr_api::Result<List> {
     with_regionset!(rs_ptr, rs, {
         with_assembly!(assembly_ptr, asm, {
             let (labels, matrix) = calc_dinucl_freq_per_region(rs, asm)
@@ -1251,7 +1305,8 @@ extendr_module! {
     // GC / Dinucleotide
     fn r_load_genome_assembly;
     fn r_calc_gc_content;
-    fn r_calc_dinucl_freq;
+    fn r_calc_dinucl_freq_global;
+    fn r_calc_dinucl_freq_per_region;
     // Interval Ranges
     fn r_trim;
     fn r_promoters;


### PR DESCRIPTION
## Summary

Combined finalization of binding alignment audit. Three related fixes:

### 1. Expose `calc_gc_content` + both `calc_dinucl_freq` variants in CLI

- Add `--fasta <PATH>` flag to `gtars genomicdist` subcommand
- Add `--ignore-unk-chroms` flag (default: `false`, matches Python)
- When `--fasta` is provided, output JSON gains three fields:
  - `gc_content: {mean, per_region}`
  - `dinucl_freq`: global dinucleotide counts
  - `dinucl_freq_per_region: {region_labels, dinucleotides, frequencies}`

### 2. Python: rename + add missing variant

- Renamed `calc_dinucleotide_frequency` → `calc_dinucl_freq` (matches core name)
- Added `calc_dinucl_freq_per_region` (was missing entirely)
- **Breaking change**: `calc_dinucleotide_frequency` no longer exists

### 3. R binding fixes

- **Naming bug fix**: `r_calc_dinucl_freq` was wrapping `calc_dinucl_freq_per_region` — R users calling by this name were silently getting per-region data instead of global counts. Renamed to `r_calc_dinucl_freq_per_region`. Added new `r_calc_dinucl_freq` wrapping the global variant. **Breaking change**.
- Standardized `ignore_unk_chroms` to optional (defaults `false`, matching Python)
- Type cast audit: changed `u32 → i32` to `u32 → f64` for coordinate/width/count values. Widths can exceed `i32::MAX` (2.1 Gbp) for concatenated/genome-scale regions. Return types change from integer to double vectors for `r_calc_widths`, `r_calc_nearest_neighbors`, `r_chromosome_statistics`.

## Deferred

WASM bindings for `calc_gc_content` / `calc_dinucl_freq` skipped: would require a `GenomeAssembly` wrapper + client-side FASTA loading (multi-GB), which is impractical for browser use cases.

## Test results

| Suite | Result |
|---|---|
| `cargo test -p gtars-genomicdist` | 261 passed |
| `pytest tests/` (gtars-python) | 146 passed |
| CLI smoke (hg38 FASTA) | ✓ GC mean 0.659, dinucl counts, per-region rows sum to 100% |

## Test plan

- [ ] Review R breaking change (renamed `r_calc_dinucl_freq`) — R users who previously called this were getting per-region output, now they get global counts. If R wrapper functions exist downstream, they need updating.
- [ ] Review Python breaking change (renamed `calc_dinucleotide_frequency`)
- [ ] Consider whether R type return changes (integer → double) need downstream R wrapper updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)