### PR TITLE
Fix export_fasta_from_regions to output one header per region

### DIFF
--- a/gtars-refget/src/store/export.rs
+++ b/gtars-refget/src/store/export.rs
@@ -3,7 +3,6 @@
 use super::*;
 use super::readonly::ReadonlyRefgetStore;
 
-use std::collections::HashMap;
 use std::ffi::OsStr;
 
 use indexmap::IndexMap;
@@ -216,53 +215,16 @@ impl ReadonlyRefgetStore {
             Box::new(file)
         };
 
-        let collection_key = collection_digest.as_ref().to_key();
-
-        let name_to_metadata: HashMap<String, SequenceMetadata> = self
-            .name_lookup
-            .get(&collection_key)
-            .map(|name_map| {
-                name_map
-                    .iter()
-                    .filter_map(|(name, seq_digest)| {
-                        self.sequence_store.get(seq_digest).map(|record| {
-                            (name.clone(), record.metadata().clone())
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
         let seq_iter = self.substrings_from_regions(&collection_digest, bed_file_path)?;
-
-        let mut previous_parsed_chr = String::new();
-        let mut current_header: String = String::new();
-        let mut previous_header: String = String::new();
 
         for rs in seq_iter.into_iter() {
             let rs = rs?;
 
-            if previous_parsed_chr != rs.chrom_name {
-                previous_parsed_chr = rs.chrom_name.clone();
-
-                if let Some(meta) = name_to_metadata.get(&rs.chrom_name) {
-                    current_header =
-                        format!(">{} {} {} {} {}", meta.name, meta.length, meta.alphabet, meta.sha512t24u, meta.md5);
-                }
-            }
-
-            let retrieved_substring = rs.sequence;
-
-            if previous_header != current_header {
-                let prefix = if previous_header.is_empty() { "" } else { "\n" };
-
-                previous_header = current_header.clone();
-
-                let header_to_be_written = format!("{}{}\n", prefix, current_header);
-                writer.write_all(header_to_be_written.as_bytes())?;
-            }
-
-            writer.write_all(retrieved_substring.as_ref())?;
+            // Write one header per region with coordinates
+            let header = format!(">{}:{}-{}\n", rs.chrom_name, rs.start, rs.end);
+            writer.write_all(header.as_bytes())?;
+            writer.write_all(rs.sequence.as_bytes())?;
+            writer.write_all(b"\n")?;
         }
 
         writer.flush()?;

--- a/gtars-refget/src/store/tests.rs
+++ b/gtars-refget/src/store/tests.rs
@@ -196,9 +196,6 @@ GGGGAAAA
 
     let collection_digest_ref: &str = "uC_UorBNf3YUu1YIDainBhI94CedlNeH";
 
-    let (chr1_sha, chr1_md5) = calculate_test_digests(b"ATGCATGCATGC");
-    let (chr2_sha, chr2_md5) = calculate_test_digests(b"GGGGAAAA");
-
     // Test BED-based export
     let bed_content = "\
 chr1\t0\t5
@@ -221,10 +218,7 @@ chr2\t0\t4
     let output_fa_content =
         fs::read_to_string(&temp_output_fa_path).expect("Failed to read output FASTA file");
 
-    let expected_fa_content = format!(
-        ">chr1 12 dna2bit {} {}\nATGCAATGC\n>chr2 8 dna2bit {} {}\nGGGG\n",
-        chr1_sha, chr1_md5, chr2_sha, chr2_md5
-    );
+    let expected_fa_content = ">chr1:0-5\nATGCA\n>chr1:8-12\nATGC\n>chr2:0-4\nGGGG\n";
     assert_eq!(
         output_fa_content.trim(),
         expected_fa_content.trim(),


### PR DESCRIPTION
## Summary
- Fixes a bug where `export_fasta_from_regions` was outputting one header per chromosome, concatenating sequences from multiple regions without separators
- Now correctly outputs standard FASTA with one header per BED region in format `>chr:start-end`

## The bug
Before this fix, extracting 5 regions from 2 chromosomes would produce output like:
```
>chr1
<seq1><seq2><seq3>
>chr2
<seq4><seq5>
```

After this fix:
```
>chr1:10000-10100
<seq1>
>chr1:20000-20100
<seq2>
...
```

## Test plan
- [x] Verified on 5-region test BED file: outputs 5 separate FASTA entries
- [x] Each entry has correct coordinates in header
- [x] Sequences match expected regions