### PR TITLE
Per-component tag-triggered releases

### DIFF
--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -63,8 +63,46 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
+  # Publish exactly one crate to crates.io, keyed off a release tag of the form
+  # `<crate>-v<version>` (e.g. `gtars-refget-v0.9.1`). The crate name is the tag
+  # with the trailing `-v<version>` stripped. Dependencies must already be on
+  # crates.io, so cut crate releases in dependency order (gtars-core before
+  # gtars-refget, then gtars, etc.). Tags that don't name a crates.io package
+  # (the pure bindings) are skipped here.
+  publish-crate:
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Resolve crate from tag and publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          CRATE="${TAG%-v*}"
+          # Workspace members published to crates.io (everything except the pure
+          # bindings gtars-python / gtars-r / gtars-wasm / gtars-node).
+          CRATES="gtars-core gtars-io gtars-overlaprs gtars-refget gtars-uniwig gtars-bbcache gtars-fragsplit gtars-tokenizers gtars-igd gtars-scoring gtars-genomicdist gtars-vrs gtars gtars-cli"
+          case " $CRATES " in
+            *" $CRATE "*) : ;;
+            *) echo "Tag '$TAG' -> '$CRATE' is not a crates.io package; skipping crate publish."; exit 0 ;;
+          esac
+          if cargo publish -p "$CRATE" --locked 2>publish_err.log; then
+            echo "published $CRATE"
+          elif grep -qiE "already uploaded|already exists" publish_err.log; then
+            echo "$CRATE already on crates.io — skipping"
+          else
+            cat publish_err.log >&2
+            exit 1
+          fi
+
+  # Emergency "republish the whole workspace" path. No longer runs on a
+  # release — releases publish a single crate via `publish-crate` (keyed off
+  # the `<crate>-v<version>` tag). Kept for manual dispatch only.
   publish-all-crates:
-    if: ${{ github.event_name == 'release' || inputs.crates == 'all' || inputs.crates == '' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && (inputs.crates == 'all' || inputs.crates == '') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -259,27 +297,35 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
+  # Bindings build from source in-repo (path deps), so none of them need the
+  # crates published first. Each runs only when its own `<package>-v*` release
+  # tag is cut (or when explicitly toggled on a manual dispatch).
   publish-python:
-    if: ${{ always() && (github.event_name == 'release' || inputs.python != false) && needs.publish-all-crates.result == 'success' }}
-    needs: publish-all-crates
+    if: >-
+      ${{ (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'gtars-python-v'))
+        || (github.event_name == 'workflow_dispatch' && inputs.python) }}
     uses: ./.github/workflows/build-python-bindings.yml
     secrets: inherit
 
   publish-cli:
-    if: ${{ always() && (github.event_name == 'release' || inputs.cli != false) && needs.publish-all-crates.result == 'success' }}
-    needs: publish-all-crates
+    if: >-
+      ${{ (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'gtars-cli-v'))
+        || (github.event_name == 'workflow_dispatch' && inputs.cli) }}
     uses: ./.github/workflows/build-binaries.yml
     secrets: inherit
 
-  # R bindings build from source in-repo, so this does not need the crates to
-  # be published first. Attaches the prebuilt binary tarball to the release.
+  # Attaches the prebuilt binary tarball to the release (gtars-r-v* tags only).
   publish-r:
-    if: ${{ always() && (github.event_name == 'release' || inputs.r != false) }}
+    if: >-
+      ${{ (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'gtars-r-v'))
+        || (github.event_name == 'workflow_dispatch' && inputs.r) }}
     uses: ./.github/workflows/build-r-bindings.yml
     secrets: inherit
 
   publish-wasm:
-    if: ${{ always() && (github.event_name == 'release' || inputs.wasm != false) }}
+    if: >-
+      ${{ (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'gtars-wasm-v'))
+        || (github.event_name == 'workflow_dispatch' && inputs.wasm) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -304,7 +350,9 @@ jobs:
           fi
 
   build-node:
-    if: ${{ always() && (github.event_name == 'release' || inputs.node != false) }}
+    if: >-
+      ${{ (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'gtars-node-v'))
+        || (github.event_name == 'workflow_dispatch' && inputs.node) }}
     strategy:
       matrix:
         include:
@@ -334,7 +382,7 @@ jobs:
           path: gtars-node/*.node
 
   publish-node:
-    if: ${{ always() && (github.event_name == 'release' || inputs.node != false) && needs.build-node.result == 'success' }}
+    if: ${{ always() && needs.build-node.result == 'success' }}
     needs: build-node
     runs-on: ubuntu-latest
     steps:
@@ -403,22 +451,3 @@ jobs:
             exit 1
           fi
 
-  create-tags:
-    if: ${{ always() && (inputs.crates == 'all' || inputs.crates == '') }}
-    needs: [publish-python, publish-cli, publish-wasm, publish-node, publish-r]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-      - name: Create component tags
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          for prefix in py cli wasm node r; do
-            TAG="${prefix}-${VERSION}"
-            git tag -f "$TAG"
-            git push -f origin "$TAG"
-          done

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ This repository is a work in progress, and still in early development. This repo
 
 1. Each piece of core functionality is implemented as a separate rust crate and is mostly independent.
 2. Common functionality (structs, traits, helpers) are stored in a `gtars-core` crate.
-3. Python bindings are stored in `gtars-py`. They pull in the necessary rust crates and provide a Pythonic interface.
+3. Python bindings are stored in `gtars-python`. They pull in the necessary rust crates and provide a Pythonic interface.
 4. A command-line interface is implemented in the `gtars-cli` crate.
+
+### Releasing
+
+Each component is versioned and released independently. To release one, bump its version, then cut a GitHub release whose tag names the component: `<package>-v<version>` (e.g. `gtars-refget-v0.9.1`, `gtars-r-v0.9.2`, `gtars-python-v0.10.0`). Only that component publishes (to crates.io, PyPI, or npm; the R and CLI releases also attach prebuilt binaries). See [RELEASING.md](RELEASING.md) for the full scheme.
 
 ## Installation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,61 @@
+# Releasing
+
+gtars is a monorepo of independently-versioned components. Each component is
+released **on its own**, when you decide it ships — there is no longer a single
+"release everything" event.
+
+## The rule
+
+A release is a GitHub Release whose **tag names the component and its version**:
+
+```
+<package>-v<version>
+```
+
+`<package>` is the exact workspace package name (the `name` in its `Cargo.toml`,
+or the R package). Cutting that release publishes **only** that component, and
+the Release itself stands as the commit-pinned, browsable marker for it.
+
+| Tag | Publishes to | Attaches asset? |
+|-----|--------------|-----------------|
+| `gtars-python-v<ver>` | PyPI | no |
+| `gtars-r-v<ver>` | (built in Bioconductor container) | yes — R binary tarball |
+| `gtars-cli-v<ver>` | crates.io **and** CLI binaries | yes — CLI binaries |
+| `gtars-wasm-v<ver>` | npm (`@databio/gtars`) | no |
+| `gtars-node-v<ver>` | npm (`@databio/gtars-node`) | no |
+| `gtars-core-v<ver>` | crates.io | no |
+| `gtars-refget-v<ver>` | crates.io | no |
+| `gtars-v<ver>` | crates.io (meta crate) | no |
+| `gtars-<crate>-v<ver>` | crates.io | no |
+
+The `-v` delimiter is load-bearing: `gtars-v0.9.1` (the meta crate) does **not**
+collide with `gtars-core-v0.5.7` etc., because the character after `gtars-`
+differs (`v` vs `c`). Keep the `-v`.
+
+## How to cut a release
+
+1. Bump the component's version (e.g. `gtars-r/DESCRIPTION` + `gtars-r/src/rust/Cargo.toml`,
+   or the crate's `Cargo.toml`). Merge to `master`.
+2. Create the GitHub Release (e.g. with `releasegh`), naming the tag
+   `<package>-v<version>` and writing release notes.
+3. Only that component's job runs; everything else is skipped.
+
+## Bindings vs crates
+
+- **Bindings (python, r, cli, wasm, node)** build from source via in-repo path
+  dependencies, so they always compile current monorepo source. There is **no
+  dependency cascade** — a binding release is fully self-contained.
+- **crates.io crates** depend on each other. Because dependencies are caret
+  ranges (`version = "0.5.6"` means `>=0.5.6, <0.6`), a patch/minor bump of a
+  dependency is picked up automatically downstream — no action needed. Only a
+  **breaking** bump (e.g. `gtars-core` 0.5 → 0.6) requires re-releasing the
+  dependents, **in dependency order**: cut `gtars-core-v0.6.0`, wait for
+  crates.io indexing, then `gtars-refget-v…`, then `gtars-v…`. A single-crate
+  release will fail if its dependencies aren't already on crates.io.
+
+## Manual / emergency publishing
+
+`rust-publish.yml` still supports `workflow_dispatch` with per-target toggles
+(`python`, `cli`, `wasm`, `node`, `r`) and a `crates` selector
+(`all` / `none` / a single crate). Use this to publish without cutting a
+Release, or to republish the entire workspace (`crates: all`) in an emergency.


### PR DESCRIPTION
Switches releases from a single monolithic GitHub Release (which fanned out and re-published **every** component) to **per-component releases**: each component publishes only when its own `<package>-v<version>` release tag is cut.

## How it works
- Each job in `rust-publish.yml` is gated on `startsWith(github.event.release.tag_name, 'gtars-<pkg>-v')`.
- The tag prefix is the exact workspace package name (no shorthand): `gtars-python-v*` → PyPI, `gtars-r-v*` → R binary, `gtars-cli-v*` → crates.io + CLI binaries, `gtars-wasm-v*`/`gtars-node-v*` → npm, `gtars-<crate>-v*` / `gtars-v*` → crates.io.
- The `-v` delimiter keeps `gtars-v*` (meta crate) from colliding with `gtars-core-v*` etc.

## Changes
- **Bindings decoupled from crates.io** — dropped `needs: publish-all-crates` from python/cli; they build from source (path deps), so there's no dependency cascade.
- **New `publish-crate` job** — on a release, strips `-v<version>` from the tag and publishes that single crate (skips pure bindings; dependencies must already be on crates.io, so cut crate releases in dependency order).
- **Retired the fanout** — `publish-all-crates` is now manual-`workflow_dispatch` only (emergency "republish everything"); the `create-tags` job (force-pushed `py-`/`r-` shorthand tags) is removed.
- **Docs** — added `RELEASING.md` and a brief note in the README; also fixed a stale `gtars-py` → `gtars-python` reference.

Normal flow: bump the component version, merge, then `releasegh` a release named `<package>-v<version>`.

## Verification
- `rust-publish.yml` YAML validated; tag→crate parsing and the `gtars-v` disambiguation unit-tested locally.
- Reusable workflows only trigger via `workflow_call`/`workflow_dispatch`, so `rust-publish.yml` stays the sole release entry point.
- Not yet exercised against a live release (would need an actual release cut).