### PR TITLE
feat(refget): persist logical sequence-data size in rgstore.json

### DIFF
--- a/gtars-node/src/lib.rs
+++ b/gtars-node/src/lib.rs
@@ -67,6 +67,7 @@ pub struct StoreStatsJs {
     pub n_collections: u32,
     pub n_collections_loaded: u32,
     pub storage_mode: String,
+    pub logical_sequence_bytes: BigInt,
 }
 
 // -- Main wrapper class --
@@ -272,6 +273,7 @@ impl RefgetStore {
             n_collections: s.n_collections as u32,
             n_collections_loaded: s.n_collections_loaded as u32,
             storage_mode: s.storage_mode,
+            logical_sequence_bytes: BigInt::from(s.logical_sequence_bytes),
         })
     }
 

--- a/gtars-python/src/refget/mod.rs
+++ b/gtars-python/src/refget/mod.rs
@@ -2064,7 +2064,7 @@ impl PyRefgetStore {
     /// Returns statistics about the store.
     ///
     /// Returns:
-    ///     dict: Dictionary with keys 'n_sequences', 'n_collections', 'n_collections_loaded', 'storage_mode'
+    ///     dict: Dictionary with keys 'n_sequences', 'n_sequences_loaded', 'n_collections', 'n_collections_loaded', 'storage_mode', 'logical_sequence_bytes'
     ///
     /// Note:
     ///     n_collections is the total number of collections (both loaded and stubs).
@@ -2095,6 +2095,10 @@ impl PyRefgetStore {
             extended_stats.n_collections_loaded.to_string(),
         );
         stats.insert("storage_mode".to_string(), extended_stats.storage_mode);
+        stats.insert(
+            "logical_sequence_bytes".to_string(),
+            extended_stats.logical_sequence_bytes.to_string(),
+        );
         stats
     }
 
@@ -3224,6 +3228,10 @@ impl PyReadonlyRefgetStore {
         stats.insert("n_collections".to_string(), extended_stats.n_collections.to_string());
         stats.insert("n_collections_loaded".to_string(), extended_stats.n_collections_loaded.to_string());
         stats.insert("storage_mode".to_string(), extended_stats.storage_mode);
+        stats.insert(
+            "logical_sequence_bytes".to_string(),
+            extended_stats.logical_sequence_bytes.to_string(),
+        );
         stats
     }
 

--- a/gtars-r/src/rust/src/refget.rs
+++ b/gtars-r/src/rust/src/refget.rs
@@ -546,7 +546,8 @@ pub fn stats_store(store_ptr: Robj) -> extendr_api::Result<List> {
             n_sequences_loaded = stats.n_sequences_loaded as i32,
             n_collections = stats.n_collections as i32,
             n_collections_loaded = stats.n_collections_loaded as i32,
-            storage_mode = stats.storage_mode
+            storage_mode = stats.storage_mode,
+            logical_sequence_bytes = stats.logical_sequence_bytes as f64
         ))
     })
 }

--- a/gtars-refget/src/store/mod.rs
+++ b/gtars-refget/src/store/mod.rs
@@ -282,6 +282,12 @@ pub(crate) struct StoreMetadata {
     /// SHA256 digest of combined FHR sidecar data
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) fhr_digest: Option<String>,
+    /// Logical sequence-data size in bytes (sum of length x storage-mode encoding),
+    /// computed once at index-write time. Lets a consumer read the store's size from
+    /// the manifest without loading the sequence index. Excludes index/sidecar
+    /// overhead. `None` for manifests written before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) logical_sequence_bytes: Option<u64>,
 }
 
 pub(crate) fn default_true() -> bool {
@@ -301,6 +307,10 @@ pub struct StoreStats {
     pub n_collections_loaded: usize,
     /// Storage mode (Raw or Encoded)
     pub storage_mode: String,
+    /// Logical size in bytes of all sequence payloads (length x storage-mode
+    /// encoding). Excludes index/sidecar/manifest overhead. For the exact full
+    /// on-disk footprint use `ReadonlyRefgetStore::actual_disk_usage()`.
+    pub logical_sequence_bytes: u64,
 }
 
 /// Format bytes into human-readable size (KB, MB, GB, etc.)

--- a/gtars-refget/src/store/persistence.rs
+++ b/gtars-refget/src/store/persistence.rs
@@ -171,6 +171,7 @@ impl ReadonlyRefgetStore {
             sequences_digest,
             aliases_digest,
             fhr_digest,
+            logical_sequence_bytes: Some(self.logical_sequence_bytes() as u64),
         };
 
         let json = serde_json::to_string_pretty(&metadata)
@@ -287,7 +288,8 @@ impl ReadonlyRefgetStore {
     /// Read the store metadata from rgstore.json, returning state digests and timestamp.
     ///
     /// Returns a HashMap with keys: modified, collections_digest, sequences_digest,
-    /// aliases_digest, fhr_digest. Missing values are omitted from the map.
+    /// aliases_digest, fhr_digest, logical_sequence_bytes. Missing values are omitted
+    /// from the map.
     pub fn store_metadata(&self) -> Result<HashMap<String, String>> {
         let local_path = self.local_path.as_ref().context("local_path not set")?;
         let json = fs::read_to_string(local_path.join("rgstore.json"))
@@ -301,6 +303,7 @@ impl ReadonlyRefgetStore {
         if let Some(v) = metadata.sequences_digest { map.insert("sequences_digest".to_string(), v); }
         if let Some(v) = metadata.aliases_digest { map.insert("aliases_digest".to_string(), v); }
         if let Some(v) = metadata.fhr_digest { map.insert("fhr_digest".to_string(), v); }
+        if let Some(v) = metadata.logical_sequence_bytes { map.insert("logical_sequence_bytes".to_string(), v.to_string()); }
         Ok(map)
     }
 

--- a/gtars-refget/src/store/readonly.rs
+++ b/gtars-refget/src/store/readonly.rs
@@ -622,15 +622,23 @@ impl ReadonlyRefgetStore {
         self.sequence_store.values().map(|rec| rec.metadata())
     }
 
-    /// Calculate the total disk size of all sequences in the store
-    pub fn total_disk_size(&self) -> usize {
+    /// Logical size in bytes of all sequence *payloads*, computed from metadata
+    /// (length x storage mode). Cheap: O(n_sequences) arithmetic, no I/O, no walk,
+    /// works on stubs. Does NOT include index files, sidecars, or rgstore.json.
+    /// This is the value cached in the manifest at write time (see write path); for
+    /// the exact full on-disk footprint use `actual_disk_usage()` (walks the dir).
+    pub fn logical_sequence_bytes(&self) -> usize {
         self.sequence_store
             .values()
             .map(|rec| rec.metadata().disk_size(&self.mode))
             .sum()
     }
 
-    /// Returns the actual disk usage of the store directory.
+    /// Exact on-disk footprint of the store: recursively walks the store directory
+    /// and sums every file's byte length (`.seq` data, `.rgsi`/`.rgci` indexes, FHR
+    /// sidecars, alias data, `rgstore.json`). Accurate and complete, but does I/O on
+    /// every call. Use this when an exact footprint is needed; for the cheap cached
+    /// sequence-content size use `logical_sequence_bytes()`.
     pub fn actual_disk_usage(&self) -> usize {
         let Some(path) = &self.local_path else {
             return 0;
@@ -2218,6 +2226,7 @@ impl ReadonlyRefgetStore {
             n_collections,
             n_collections_loaded,
             storage_mode: mode_str.to_string(),
+            logical_sequence_bytes: self.logical_sequence_bytes() as u64,
         }
     }
 
@@ -2232,7 +2241,7 @@ impl ReadonlyRefgetStore {
 
 impl Display for ReadonlyRefgetStore {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let total_size = self.total_disk_size();
+        let total_size = self.logical_sequence_bytes();
         let size_str = format_bytes(total_size);
         writeln!(f, "ReadonlyRefgetStore object:")?;
         writeln!(f, "  Mode: {:?}", self.mode)?;

--- a/gtars-refget/src/store/tests.rs
+++ b/gtars-refget/src/store/tests.rs
@@ -919,7 +919,7 @@ fn test_disk_size_calculation() {
         .add_sequence_collection_from_fasta("../tests/data/fasta/base.fa.gz", FastaImportOptions::new())
         .unwrap();
 
-    let disk_size = store.total_disk_size();
+    let disk_size = store.logical_sequence_bytes();
     assert!(disk_size > 0);
 
     let manual: usize = store
@@ -1553,6 +1553,62 @@ fn test_aliases_digest_changes_on_alias_add() {
 
     let meta2 = store.store_metadata().unwrap();
     assert!(meta2.get("aliases_digest").is_some(), "aliases_digest should appear after alias + index rewrite");
+}
+
+#[test]
+fn test_logical_sequence_bytes_persisted_in_manifest() {
+    let dir = tempdir().unwrap();
+    let store_path = dir.path().join("store");
+
+    let mut store = RefgetStore::on_disk(&store_path).unwrap();
+    store
+        .add_sequence_collection_from_fasta("../tests/data/fasta/base.fa", FastaImportOptions::new())
+        .unwrap();
+
+    let expected = store.logical_sequence_bytes() as u64;
+    assert!(expected > 0);
+
+    // Read the raw rgstore.json and confirm the cached value matches.
+    let json = fs::read_to_string(store_path.join("rgstore.json")).unwrap();
+    let manifest: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        manifest.get("logical_sequence_bytes").and_then(|v| v.as_u64()),
+        Some(expected),
+        "manifest should cache logical_sequence_bytes matching the store"
+    );
+
+    // store_metadata() should surface it too.
+    let meta = store.store_metadata().unwrap();
+    assert_eq!(
+        meta.get("logical_sequence_bytes").map(|s| s.as_str()),
+        Some(expected.to_string().as_str())
+    );
+}
+
+#[test]
+fn test_logical_sequence_bytes_survives_alias_refresh() {
+    let dir = tempdir().unwrap();
+    let store_path = dir.path().join("store");
+
+    let mut store = RefgetStore::on_disk(&store_path).unwrap();
+    let (meta, _) = store
+        .add_sequence_collection_from_fasta("../tests/data/fasta/base.fa", FastaImportOptions::new())
+        .unwrap();
+
+    let expected = store.logical_sequence_bytes() as u64;
+    assert!(expected > 0);
+
+    // Alias-only mutation goes through the cheap manifest-refresh path, which must
+    // preserve the cached logical_sequence_bytes untouched.
+    store.add_sequence_alias("test_ns", "my_alias", &meta.sequences_digest).unwrap();
+
+    let json = fs::read_to_string(store_path.join("rgstore.json")).unwrap();
+    let manifest: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        manifest.get("logical_sequence_bytes").and_then(|v| v.as_u64()),
+        Some(expected),
+        "logical_sequence_bytes should survive an alias-only refresh"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Rename total_disk_size() -> logical_sequence_bytes() (cheap, no-I/O, sequence-content-only) and cache the value in StoreMetadata at index-write time so consumers can read a store's size from the manifest without loading the sequence index. Carries through the alias-refresh path untouched; surfaced via store_metadata() and StoreStats/stats(). Propagated to Node/Python/R bindings.